### PR TITLE
prefer Python 3

### DIFF
--- a/trunk.sh
+++ b/trunk.sh
@@ -29,15 +29,15 @@ printf "${YEL}Downloading PGO Profiles for Linux, Windows, and Mac...\n" &&
 printf "\n" &&
 tput sgr0 &&
 
-python tools/update_pgo_profiles.py --target=linux update --gs-url-base=chromium-optimization-profiles/pgo_profiles &&
+python3 tools/update_pgo_profiles.py --target=linux update --gs-url-base=chromium-optimization-profiles/pgo_profiles &&
 
-python tools/update_pgo_profiles.py --target=win64 update --gs-url-base=chromium-optimization-profiles/pgo_profiles &&
+python3 tools/update_pgo_profiles.py --target=win64 update --gs-url-base=chromium-optimization-profiles/pgo_profiles &&
 
-python tools/update_pgo_profiles.py --target=mac update --gs-url-base=chromium-optimization-profiles/pgo_profiles &&
+python3 tools/update_pgo_profiles.py --target=mac update --gs-url-base=chromium-optimization-profiles/pgo_profiles &&
 
 printf "\n" &&
 
-printf "${YEL}Done!  You can now run ./setup.sh.\n"
+printf "${YEL}Done! You can now run ./setup.sh.\n"
 tput sgr0
 
 exit 0


### PR DESCRIPTION
Hi,

current MacOS 12.3 lost Python 2 support. So I need those PGO commands for Python 3.

Does this PR break things for you, @Alex313031?

Cheers
midzer