### PR TITLE
README fix JPEGXL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 > - Various compiler flags that improve performance and target [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) CPU's (read [PATCHES.md](https://github.com/Alex313031/Thorium/blob/main/infra/PATCHES.md))
 > - Experimental [MPEG-DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) support.
 > - HEVC/H.265 support on Linux and Windows.
-> - [JPEG XL](https://jpeg.org/jpegxl/) Image File Format support.
+> - [JPEG XL](https://jpeg.org/jpegxl/) Image File Format turned on by default.
 > - Enable [Live Caption](https://support.google.com/chrome/answer/10538231?hl) (SODA) on all builds.
 > - Experimental PDF annotation support (called "Ink" on ChromiumOS). # DISABLED FOR NOW BECAUSE OF CRASHES.
 > - Patches from Debian including font rendering patch, VAAPI Patch, Intel HD support patch, native notifications patch, title bar patch, and... the VDPAU Patch!! (Rejoice Nvidia users)


### PR DESCRIPTION
Chrome & Fx have JPEGXL, but behind flags.  Turned on by default is a feature!
https://caniuse.com/jpegxl

Thanks again for your project!