### PR TITLE
Fix duplicate HTML ID in Win7 variant of chrome://version

### DIFF
--- a/other/WIN7/about_version.html
+++ b/other/WIN7/about_version.html
@@ -64,8 +64,7 @@ about:version template page
         </picture>
 </if>
         <div id="company"><a target="_blank" rel="noopener" href="https://github.com/Alex313031/Thorium">$i18n{company}</a></div>
-        <div id="copyright">$i18n{copyright}</div>
-        <div id="copyright">Dis is Das Special Windows 7 Build!</div>
+        <div id="copyright">$i18n{copyright}<br>Dis is Das Special Windows 7 Build!</div>
       </div>
       <table id="inner" cellpadding="0" cellspacing="0" border="0">
         <tr><td class="label">$i18n{application_label}</td>


### PR DESCRIPTION
Duplicate ID attribute is a fundamental HTML error. Feel free to reject this PR and/or fix it your own way 🙂