### PR TITLE
Update NTP patch and delete some redundant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
 > - Enable [Live Caption](https://support.google.com/chrome/answer/10538231?hl) (SODA) on all builds.
 > - Experimental PDF annotation support (called "Ink" on ChromiumOS). # DISABLED FOR NOW BECAUSE OF CRASHES.
 > - Patches from Debian including font rendering patch, VAAPI Patch, Intel HD support patch, native notifications patch, title bar patch, and... the VDPAU Patch!! (Rejoice Nvidia users)
-> - REMOVED ~VAAPI on Wayland Patch (Thanks AUR and @pierro78)~
 > - Audio Sandbox patch.
 > - [DoH](https://en.wikipedia.org/wiki/DNS_over_HTTPS) (DNS over HTTPS) patches from Bromite.
 > - Enable [Do Not Track](https://allaboutdnt.com/) by default patch from Vanadium.

--- a/other/AVX2/build/config/compiler/BUILD.gn
+++ b/other/AVX2/build/config/compiler/BUILD.gn
@@ -1041,7 +1041,7 @@ config("compiler") {
     "-Zremap-cwd-prefix=.",
 
     # Full RUSTC optimizations.
-    "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma,+fma",
+    "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma",
     "-Cllvm-args=-fp-contract=fast",
   ]
 
@@ -2563,7 +2563,7 @@ config("optimize") {
       # Favor size over speed, /O1 must be before the common flags.
       # /O1 implies /Os and /GF.
       cflags = [ "/O2", "-Xclang", "-O3", ] + common_optimize_on_cflags
-      rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma,+fma" ]
+      rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma" ]
     } else {
       # PGO requires all translation units to be compiled with /O2. The actual
       # optimization level will be decided based on the profiling data.
@@ -2572,7 +2572,7 @@ config("optimize") {
       # https://doc.rust-lang.org/rustc/profile-guided-optimization.html#usage
       # suggests not using an explicit `-Copt-level` at all, and the default is
       # to optimize for performance like `/O2` for clang.
-      rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma,+fma" ]
+      rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma" ]
     }
   } else if (optimize_for_size) {
     # Favor size over speed.
@@ -2591,7 +2591,7 @@ config("optimize") {
 
     # Like with `-Oz` on Clang, `-Copt-level=z` will also turn off loop
     # vectorization.
-    rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma,+fma" ]
+    rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma" ]
   } else if (is_chromeos) {
     # TODO(gbiv): This is partially favoring size over speed. CrOS exclusively
     # uses clang, and -Os in clang is more of a size-conscious -O2 than "size at
@@ -2603,14 +2603,14 @@ config("optimize") {
 
     # Similar to clang, we optimize with `-Copt-level=s` to keep loop
     # vectorization while otherwise optimizing for size.
-    rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma,+fma" ]
+    rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma" ]
   } else {
     cflags = [ "-O3" ] + common_optimize_on_cflags
 
     # The `-O3` for clang turns on extra optimizations compared to the standard
     # `-O2`. But for rust, `-Copt-level=3` is the default and is thus reliable
     # to use.
-    rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma,+fma" ]
+    rustflags = [ "-Copt-level=3", "-Ctarget-feature=+aes,+avx,+avx2,+fma" ]
   }
   ldflags = common_optimize_on_ldflags
 }

--- a/other/Remove-discovery-module-from-NTP.patch
+++ b/other/Remove-discovery-module-from-NTP.patch
@@ -1,6 +1,6 @@
-From 6d9b50008f8e3a27396cf7e2936f2ad6ce882dc8 Mon Sep 17 00:00:00 2001
+From ce88a53607ea21bbfadea732ba5d9ae54a14309e Mon Sep 17 00:00:00 2001
 From: Ho Cheung
-Date: Thu, 25 Jan 2024 11:07:21 +0800
+Date: Sun, 18 Feb 2024 14:36:32 +0800
 Subject: [PATCH] Remove-discovery-module-from-NTP
 
 ---
@@ -10,14 +10,14 @@ Subject: [PATCH] Remove-discovery-module-from-NTP
  3 files changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml b/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml
-index ee1283cb9a6a0..c89b236330bf9 100644
+index 31f70ed8cc655..cf9e2978e634d 100644
 --- a/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml
 +++ b/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml
 @@ -1,6 +1,6 @@
  <?xml version="1.0" encoding="utf-8"?>
  <!--
 -Copyright 2020 The Chromium Authors
-+Copyright 2023 The Chromium Authors, Alex313031 and gz83
++Copyright 2024 The Chromium Authors, Alex313031 and gz83
  Use of this source code is governed by a BSD-style license that can be
  found in the LICENSE file.
  -->
@@ -32,14 +32,14 @@ index ee1283cb9a6a0..c89b236330bf9 100644
      <RelativeLayout
          tools:ignore="RelativeOverlap"
 diff --git a/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml b/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml
-index 483e954de0a49..15ca071b1d30f 100644
+index febb918f29570..8a8ee82be9842 100644
 --- a/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml
 +++ b/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml
 @@ -1,6 +1,6 @@
  <?xml version="1.0" encoding="utf-8"?>
  <!--
 -Copyright 2021 The Chromium Authors
-+Copyright 2023 The Chromium Authors, Alex313031 and gz83
++Copyright 2024 The Chromium Authors, Alex313031 and gz83
  Use of this source code is governed by a BSD-style license that can be
  found in the LICENSE file.
  -->
@@ -59,7 +59,7 @@ index 7ac1995862d0b..fadb75f2031db 100644
 +++ b/components/feed/core/shared_prefs/pref_names.cc
 @@ -1,4 +1,4 @@
 -// Copyright 2020 The Chromium Authors
-+// Copyright 2023 The Chromium Authors, Alex313031 and gz83
++// Copyright 2024 The Chromium Authors, Alex313031 and gz83
  // Use of this source code is governed by a BSD-style license that can be
  // found in the LICENSE file.
  
@@ -73,5 +73,5 @@ index 7ac1995862d0b..fadb75f2031db 100644
  }
  
 -- 
-2.43.0
+2.44.0.rc0.windows.1
 


### PR DESCRIPTION
1. Update NTP patch
2. Remove duplicate `+fma` parameter in AVX2 BUILD.gn file
3. Remove unnecessary content from README

PTAL

@Alex313031 