### PR TITLE
Update and refactor Python files

### DIFF
--- a/infra/portable/make_portable_win.py
+++ b/infra/portable/make_portable_win.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import subprocess
 import sys
-import time
 import zipfile
 
 
@@ -24,77 +23,112 @@ def try_run(command):
 
 def display_help():
     print("\nScript to make a portable Thorium .zip for Windows.\n")
-    print("\nPlease place the thorium_mini_installer.exe file in this directory before running.\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 
 def copy_installer():
-    cr_src_dir = os.getenv('CR_DIR', r'C:/src/chromium/src')
-    src_path = os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium', 'thorium_mini_installer.exe'))
-    dest_path = os.path.normpath(os.path.join(os.getcwd(), 'thorium_mini_installer.exe'))
+    cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
+    installer_files = [
+        "thorium_mini_installer.exe",
+        "thorium_AVX_mini_installer.exe",
+        "thorium_AVX2_mini_installer.exe",
+        "thorium_SSE3_mini_installer.exe",
+        "thorium_SSE4_mini_installer.exe",
+    ]
 
-    if not os.path.exists(src_path):
-        fail(f"thorium_mini_installer.exe not found at {src_path}")
+    existing_files = [
+        installer_file
+        for installer_file in installer_files
+        if os.path.exists(os.path.join(os.getcwd(), installer_file))
+    ]
 
-    print(f"Copying thorium_mini_installer.exe from {src_path} to {dest_path}...\n")
-    shutil.copy(src_path, dest_path)
+    if existing_files:
+        print(
+            f"Skipping copy for existing files: {', '.join(existing_files)}\n")
+        print("Starting portable version creation.")
+        return existing_files[0]
+
+    for installer_file in installer_files:
+        src_path = os.path.normpath(
+            os.path.join(cr_src_dir, "out", "thorium", installer_file)
+        )
+        dest_path = os.path.normpath(os.path.join(os.getcwd(), installer_file))
+
+        if os.path.exists(src_path):
+            print(
+                f"Copying {installer_file} from {src_path} to {dest_path}...\n")
+            shutil.copy(src_path, dest_path)
+            return installer_file
+
+    fail("No installer file found.")
 
 
-def extract_and_copy_files():
-    # Extract and copy files
-    os.makedirs('./temp/USER_DATA', exist_ok=True)
-    try_run('7z x thorium_mini_installer.exe')
-    try_run('7z x chrome.7z')
-    shutil.move('Chrome-bin', './temp/BIN')
-    shutil.copy('./README.win', './temp/README.txt')
-    shutil.copy('./THORIUM.BAT', './temp/')
-    shutil.copy('./THORIUM_SHELL.BAT', './temp/')
+def extract_and_copy_files(installer_name):
+    os.makedirs("./temp/USER_DATA", exist_ok=True)
+    try_run(f"7z x {installer_name}")
+    try_run("7z x chrome.7z")
+    shutil.move("Chrome-bin", "./temp/BIN")
+    shutil.copy("./README.win", "./temp/README.txt")
+    shutil.copy("./THORIUM.BAT", "./temp/")
+    shutil.copy("./THORIUM_SHELL.BAT", "./temp/")
 
-def zip_files():
-    # Create zip archive
-    with zipfile.ZipFile('thorium_portable.zip', 'w', zipfile.ZIP_DEFLATED) as zf:
-        for root, _, files in os.walk('./temp'):
+
+def zip_files(installer_name):
+    version = "130.0.6723.174"
+
+    if "AVX2" in installer_name:
+        zip_filename = f"Thorium_AVX2_{version}.zip"
+    elif "AVX" in installer_name:
+        zip_filename = f"Thorium_AVX_{version}.zip"
+    elif "SSE3" in installer_name:
+        zip_filename = f"Thorium_SSE3_{version}.zip"
+    elif "SSE4" in installer_name:
+        zip_filename = f"Thorium_SSE4_{version}.zip"
+    else:
+        zip_filename = f"thorium_portable.zip"
+
+    with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, _, files in os.walk("./temp"):
+            if not files:
+                zf.write(root, os.path.relpath(root, "./temp"))
             for file in files:
                 file_path = os.path.join(root, file)
-                zf.write(file_path, os.path.relpath(file_path, './temp'))
+                zf.write(file_path, os.path.relpath(file_path, "./temp"))
+
+    print(f"Created zip archive: {zip_filename}")
+
 
 def clean_up():
-    # Cleanup extracted files
     try:
-        os.remove('chrome.7z')
-        shutil.rmtree('temp')
+        os.remove("chrome.7z")
+        shutil.rmtree("temp")
     except FileNotFoundError:
         pass
 
+
 def main():
+    print(
+        "\nNOTE: Place the Thorium .exe in this directory and ensure 7-Zip is in PATH.\n"
+    )
 
-    print("\nNOTE: You must place the thorium .exe file in this directory before running.")
-    print("   AND you must have 7-Zip installed and in your PATH.")
-    print("   Make sure to rename the .zip properly as per the release instructions.")
-    print("   AND make sure to edit the THORIUM_SHELL.BAT to match the version number of this release.\n")
-
-    copy_installer()
-
+    installer_name = copy_installer()
     input("Press Enter to continue or Ctrl + C to abort.")
 
-    print("Extracting & Copying files from thorium .exe file...\n")
-    time.sleep(2)
-
-    extract_and_copy_files()
+    print("Extracting files from installer file...\n")
+    extract_and_copy_files(installer_name)
 
     print("\nZipping up...\n")
-    zip_files()
+    zip_files(installer_name)
 
     print("\nCleaning up...\n")
-    time.sleep(2)
-
     clean_up()
 
-    print("\nDone! Zip is at ./thorium_portable.zip")
-    print("Remember to rename it with the version before distributing it.\n")
+    print("\nDone! Zip is at //infra/portable.\n")
+
 
 if __name__ == "__main__":
     main()

--- a/win_scripts/build_win.py
+++ b/win_scripts/build_win.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 
 # Error handling functions
+
+
 def fail(msg):
     # Print error message and exit
     print(f"{sys.argv[0]}: {msg}", file=sys.stderr)
@@ -22,6 +24,7 @@ def try_run(command):
 def display_help():
     print("\nScript to build Thorium for Windows.\n")
     print("Usage: python win_scripts\build_win.py # (where # is number of jobs)\n")
+
 
 if '--help' in sys.argv:
     display_help()
@@ -40,9 +43,8 @@ jobs = sys.argv[1] if len(sys.argv) > 1 else str(os.cpu_count())
 
 try_run(f'autoninja -C out/thorium thorium_all -j{jobs}')
 
-# Move the installer
-installer_src = os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium', 'mini_installer.exe'))
-installer_dest = os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium', 'thorium_mini_installer.exe'))
-os.rename(installer_src, installer_dest)
+try_run(f'autoninja -C out/thorium setup mini_installer -j{jobs}')
+
+installer_dest = os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
 
 print(f"Build Completed. Installer at '{installer_dest}'")

--- a/win_scripts/reset_depot_tools.py
+++ b/win_scripts/reset_depot_tools.py
@@ -10,7 +10,6 @@ in fact it seems that the files we need to delete have been deleted.
 # TODO(gz83): Suppress false positives during operation?
 
 import os
-import shutil
 import subprocess
 import sys
 
@@ -42,20 +41,18 @@ def remove(item_path):
 
 
 def unlock_and_delete(path):
-    """Attempts to unlock and delete a directory using cmd commands."""
-    if sys.platform == "win32":
-        # Use the Windows command line tools to unlock the directory
-        try:
-            # Use the command 'del' to delete all files recursively
-            subprocess.run(f'del /S /Q "{path}\\*"', shell=True, check=True)
-            # Use the command 'rmdir' to delete the directory
-            subprocess.run(f'rmdir /S /Q "{path}"', shell=True, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Failed to unlock and delete directory '{path}' via CMD: {e}")
-            raise PermissionError(f"Failed to unlock and delete directory '{path}' via CMD: {e}")
-    else:
-        # For other platforms, just use shutil.rmtree
-        shutil.rmtree(path)
+    """Attempts to unlock and delete a directory using Windows cmd commands."""
+    # Use the Windows command line tools to unlock the directory
+    try:
+        # Use the command 'del' to delete all files recursively
+        subprocess.run(f'del /S /Q "{path}\\*"', shell=True, check=True)
+        # Use the command 'rmdir' to delete the directory
+        subprocess.run(f'rmdir /S /Q "{path}"', shell=True, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to unlock and delete directory '{path}' via CMD: {e}")
+        raise PermissionError(
+            f"Failed to unlock and delete directory '{path}' via CMD: {e}"
+        )
 
 
 def display_help():
@@ -64,14 +61,18 @@ def display_help():
     print("from your disk, and then re-clone depot_tools.")
     print("\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 
-depot_tools_dir = os.getenv('DEPOT_TOOLS_DIR', r"C:\src\depot_tools")
-gsutil_dir = os.path.expandvars(os.getenv('GSUTIL_DIR', r'%USERPROFILE%\.gsutil'))
-vpython_root_dir = os.path.expandvars(os.getenv('VPYTHON_ROOT_DIR', r'%LOCALAPPDATA%\.vpython-root'))
+depot_tools_dir = os.getenv("DEPOT_TOOLS_DIR", r"C:\src\depot_tools")
+gsutil_dir = os.path.expandvars(
+    os.getenv("GSUTIL_DIR", r"%USERPROFILE%\.gsutil"))
+vpython_root_dir = os.path.expandvars(
+    os.getenv("VPYTHON_ROOT_DIR", r"%LOCALAPPDATA%\.vpython-root")
+)
 
 print("\nRemoving depot_tools, etc\n")
 
@@ -84,5 +85,6 @@ print("\nRe-clone depot_tools\n")
 os.chdir(os.path.dirname(depot_tools_dir))
 try_run(f"git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git")
 
-print(f"\nCompleted. You can now use the depot_tools installed at: {depot_tools_dir}\n")
+print(
+    f"\nCompleted. You can now use the depot_tools installed at: {depot_tools_dir}\n")
 print("\nYou can now run trunk.py\n")

--- a/win_scripts/setup.py
+++ b/win_scripts/setup.py
@@ -60,172 +60,220 @@ def display_help():
     print("Use the --sse2 flag for 32-bit SSE2 Builds.")
     print("\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 # Set chromium/src dir from Windows environment variable
-cr_src_dir = os.getenv('CR_DIR', r'C:/src/chromium/src')
+cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
 # Set Thorium dir from Windows environment variable
-thor_src_dir = os.path.expandvars(os.getenv('THOR_DIR', r'%USERPROFILE%/thorium'))
+thor_src_dir = os.path.expandvars(
+    os.getenv("THOR_DIR", r"%USERPROFILE%/thorium"))
 
 
 print("\nCreating build output directory...\n")
 os.makedirs(f"{cr_src_dir}/out/thorium/", exist_ok=True)
 
-print("\nCopying Thorium source files over the Chromium tree\n")
+print("\nCopying thorium-libjxl source for JPEG-XL Support\n")
 
 # Copy libjxl src
 copy_directory(
-  os.path.normpath(os.path.join(thor_src_dir, 'thorium-libjxl/src/')),
-  os.path.normpath(os.path.join(cr_src_dir))
+    os.path.normpath(os.path.join(thor_src_dir, "thorium-libjxl/src/")),
+    os.path.normpath(os.path.join(cr_src_dir)),
 )
+
+print("\nCopying Thorium source files over the Chromium tree\n")
 
 # Copy src/BUILD.gn
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'src', 'BUILD.gn')),
-    os.path.normpath(os.path.join(cr_src_dir))
+    os.path.normpath(os.path.join(thor_src_dir, "src", "BUILD.gn")),
+    os.path.normpath(os.path.join(cr_src_dir)),
 )
 
 # Copy Thorium sources
 thorium_sources = [
-    'src/ash',
-    'src/build',
-    'src/chrome',
-    'src/chromeos',
-    'src/components',
-    'src/content',
-    'src/extensions',
-    'src/google_apis',
-    'src/media',
-    'src/net',
-    'src/sandbox',
-    'src/services',
-    'src/third_party',
-    'src/tools',
-    'src/ui',
-    'src/v8'
+    "src/ash",
+    "src/build",
+    "src/chrome",
+    "src/chromeos",
+    "src/components",
+    "src/content",
+    "src/extensions",
+    "src/google_apis",
+    "src/media",
+    "src/net",
+    "src/sandbox",
+    "src/services",
+    "src/third_party",
+    "src/tools",
+    "src/ui",
+    "src/v8",
 ]
 
 for source in thorium_sources:
-    relative_path = source.replace('src/', '', 1)
+    relative_path = source.replace("src/", "", 1)
     copy_directory(
         os.path.normpath(os.path.join(thor_src_dir, source)),
-        os.path.normpath(os.path.join(cr_src_dir, relative_path))
+        os.path.normpath(os.path.join(cr_src_dir, relative_path)),
     )
 
 copy_directory(
-    os.path.normpath(os.path.join(thor_src_dir, 'thorium_shell')),
-    os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+    os.path.normpath(os.path.join(thor_src_dir, "thorium_shell")),
+    os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
 )
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'pak_src', 'binaries', 'pak')),
-    os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+    os.path.normpath(os.path.join(thor_src_dir, "pak_src", "binaries", "pak")),
+    os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
 )
 copy_directory(
-    os.path.normpath(os.path.join(thor_src_dir, 'pak_src', 'binaries', 'pak-win')),
-    os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+    os.path.normpath(os.path.join(
+        thor_src_dir, "pak_src", "binaries", "pak-win")),
+    os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
 )
 
 
 patches = [
-  'other/fix-policy-templates.patch',
-  'other/ftp-support-thorium.patch',
-  'other/thorium-2024-ui.patch',
+    "other/fix-policy-templates.patch",
+    "other/ftp-support-thorium.patch",
+    "other/thorium-2024-ui.patch",
+    "other/GPC.patch",
+    "other/GPC-2.patch",
+    "other/mini_installer.patch",
+    "other/open_in_same_tab.patch",
+    "other/thorium_webui.patch",
 ]
 for patch in patches:
-    relative_path = patch.replace('other/', '', 1)
+    relative_path = patch.replace("other/", "", 1)
     os.path.normpath(os.path.join(cr_src_dir, os.path.dirname(relative_path)))
     copy(
-      os.path.normpath(os.path.join(thor_src_dir, patch)),
-      os.path.normpath(os.path.join(cr_src_dir, relative_path))
+        os.path.normpath(os.path.join(thor_src_dir, patch)),
+        os.path.normpath(os.path.join(cr_src_dir, relative_path)),
     )
 
 
-print( "\nPatching FFMPEG for HEVC\n")
+print("\nPatching FFMPEG for HEVC\n")
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'other', 'add-hevc-ffmpeg-decoder-parser.patch')),
-    os.path.normpath(os.path.join(cr_src_dir, 'third_party', 'ffmpeg'))
+    os.path.normpath(
+        os.path.join(thor_src_dir, "other",
+                     "add-hevc-ffmpeg-decoder-parser.patch")
+    ),
+    os.path.normpath(
+        os.path.join(thor_src_dir, "other", "change-libavcodec-header.patch")
+    ),
+    os.path.normpath(os.path.join(cr_src_dir, "third_party", "ffmpeg")),
 )
 # Change directory to ffmpeg_dir and run commands
-ffmpeg_dir = os.path.join(cr_src_dir, 'third_party', 'ffmpeg')
+ffmpeg_dir = os.path.join(cr_src_dir, "third_party", "ffmpeg")
 os.chdir(ffmpeg_dir)
-try_run(f'git apply --reject add-hevc-ffmpeg-decoder-parser.patch')
+try_run(f"git apply --reject add-hevc-ffmpeg-decoder-parser.patch")
+try_run(f"git apply --reject change-libavcodec-header.patch")
 
 
-print( "\nPatching policy templates\n")
+print("\nPatching policy templates\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
-try_run(f'git apply --reject fix-policy-templates.patch')
+try_run(f"git apply --reject fix-policy-templates.patch")
 
 
-print( "\nPatching FTP support\n")
+print("\nPatching FTP support\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
-try_run(f'git apply --reject ftp-support-thorium.patch')
+try_run(f"git apply --reject ftp-support-thorium.patch")
 
 
-print( "\nPatching for Thorium 2024 UI\n")
+print("\nPatching in GPC support\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
-try_run(f'git apply --reject thorium-2024-ui.patch')
+try_run(f"git apply --reject GPC.patch")
+try_run(f"git apply --reject GPC-2.patch")
 
 
-if '--woa' not in sys.argv:
-    print("\nPatching FFMPEG for AC3 & E-AC3\n")
-    copy(
-        os.path.normpath(os.path.join(thor_src_dir, 'other', 'ffmpeg_hevc_ac3.patch')),
-        os.path.normpath(os.path.join(cr_src_dir, 'third_party', 'ffmpeg'))
-    )
-    # Change directory to ffmpeg_dir and run commands
-    ffmpeg_dir = os.path.join(cr_src_dir, 'third_party', 'ffmpeg')
-    os.chdir(ffmpeg_dir)
-    try_run(f'git apply --reject ffmpeg_hevc_ac3.patch')
-else:
-    print("\nSkipping patching FFMPEG for AC3 & E-AC3 due to --woa option.\n")
+print("\nPatching for Thorium 2024 UI\n")
+# Change directory to cr_src_dir and run commands
+os.chdir(cr_src_dir)
+try_run(f"git apply --reject thorium-2024-ui.patch")
 
+
+print("\nPatching for mini_installer\n")
+# Change directory to cr_src_dir and run commands
+os.chdir(cr_src_dir)
+try_run(f"git apply --reject mini_installer.patch")
+
+
+print("\nPatching for open_in_same_tab\n")
+# Change directory to cr_src_dir and run commands
+os.chdir(cr_src_dir)
+try_run(f"git apply --reject open_in_same_tab.patch")
+
+
+print("\nPatching for thorium_webui\n")
+# Change directory to cr_src_dir and run commands
+os.chdir(cr_src_dir)
+try_run(f"git apply --reject thorium_webui.patch")
 
 print("\nCopying other files to out/thorium\n")
 # Copying additional files
 os.makedirs(f"{cr_src_dir}/out/thorium/default_apps", exist_ok=True)
 copy_directory(
-    os.path.normpath(os.path.join(thor_src_dir, 'infra', 'default_apps')),
-    os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium', 'default_apps'))
+    os.path.normpath(os.path.join(thor_src_dir, "infra", "default_apps")),
+    os.path.normpath(os.path.join(
+        cr_src_dir, "out", "thorium", "default_apps")),
 )
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'infra', 'initial_preferences')),
-    os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+    os.path.normpath(os.path.join(
+        thor_src_dir, "infra", "initial_preferences")),
+    os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
 )
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'infra', 'thor_ver')),
-    os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+    os.path.normpath(os.path.join(thor_src_dir, "infra", "thor_ver")),
+    os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
 )
+
+flags_to_check = ["--woa", "--avx512", "--avx2", "--sse4", "--sse3", "--sse2"]
+if not any(flag in sys.argv for flag in flags_to_check):
+    os.chdir(cr_src_dir)
+    print("\nDownloading PGO Profiles for Windows x64\n")
+    try_run(
+        "python3 tools/update_pgo_profiles.py --target=win64 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
+    )
+    print("\nDownloading PGO Profile for V8\n")
+    try_run(
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
+    )
+else:
+    print(
+        "\nFor non-AVX builds, please pass the appropriate arguments to ensure the command is executed correctly.\n"
+    )
+
 
 # Copy Windows on Arm files
 def copy_woa():
     print("\nCopying Windows on Arm build files\n")
     copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'arm', 'build')),
-      os.path.normpath(os.path.join(cr_src_dir, 'build'))
+        os.path.normpath(os.path.join(thor_src_dir, "arm", "build")),
+        os.path.normpath(os.path.join(cr_src_dir, "build")),
     )
     copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'arm', 'third_party')),
-      os.path.normpath(os.path.join(cr_src_dir, 'third_party'))
+        os.path.normpath(os.path.join(thor_src_dir, "arm", "third_party")),
+        os.path.normpath(os.path.join(cr_src_dir, "third_party")),
     )
     os.chdir(cr_src_dir)
     print("\nDownloading PGO Profiles for Windows on Arm\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win-arm64 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win-arm64 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profile for V8\n")
     try_run(
-    'python3 v8/tools/builtins-pgo/download_profiles.py '
-    '--depot-tools=third_party/depot_tools --force download'
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
     )
 
 
-if '--woa' in sys.argv:
+if "--woa" in sys.argv:
     copy_woa()
 
 
@@ -233,31 +281,29 @@ if '--woa' in sys.argv:
 def copy_avx512():
     print("\nCopying AVX-512 build files\n")
     copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'AVX512', 'build')),
-      os.path.normpath(os.path.join(cr_src_dir, 'build'))
-    )
-    copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'AVX512', 'third_party')),
-      os.path.normpath(os.path.join(cr_src_dir, 'third_party'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "AVX2", "third_party")),
+        os.path.normpath(os.path.join(cr_src_dir, "third_party")),
     )
     copy(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'AVX512', 'thor_ver')),
-      os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "AVX512", "thor_ver")),
+        os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
     )
     os.chdir(cr_src_dir)
     print("\nDownloading PGO Profiles for Windows x64\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win64 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win64 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profile for V8\n")
     try_run(
-    'python3 v8/tools/builtins-pgo/download_profiles.py '
-    '--depot-tools=third_party/depot_tools --force download'
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
     )
 
 
-if '--avx512' in sys.argv:
+if "--avx512" in sys.argv:
     copy_avx512()
 
 
@@ -265,121 +311,124 @@ if '--avx512' in sys.argv:
 def copy_avx2():
     print("\nCopying AVX2 build files\n")
     copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'AVX2', 'build')),
-      os.path.normpath(os.path.join(cr_src_dir, 'build'))
-    )
-    copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'AVX2', 'third_party')),
-      os.path.normpath(os.path.join(cr_src_dir, 'third_party'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "AVX2", "third_party")),
+        os.path.normpath(os.path.join(cr_src_dir, "third_party")),
     )
     copy(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'AVX2', 'thor_ver')),
-      os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "AVX2", "thor_ver")),
+        os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
     )
     os.chdir(cr_src_dir)
     print("\nDownloading PGO Profiles for Windows x64\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win64 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win64 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profile for V8\n")
     try_run(
-    'python3 v8/tools/builtins-pgo/download_profiles.py '
-    '--depot-tools=third_party/depot_tools --force download'
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
     )
 
 
-if '--avx2' in sys.argv:
+if "--avx2" in sys.argv:
     copy_avx2()
 
 
 # Copy SSE4.1 build files
 def copy_sse4():
     print("\nCopying SSE4.1 build files\n")
-    copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'SSE4.1', 'build')),
-      os.path.normpath(os.path.join(cr_src_dir, 'build'))
-    )
     copy(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'SSE4.1', 'thor_ver')),
-      os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "SSE4.1", "thor_ver")),
+        os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
     )
     os.chdir(cr_src_dir)
     print("\nDownloading PGO Profiles for Windows x64\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win64 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win64 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profile for V8\n")
     try_run(
-    'python3 v8/tools/builtins-pgo/download_profiles.py '
-    '--depot-tools=third_party/depot_tools --force download'
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
     )
 
 
-if '--sse4' in sys.argv:
+if "--sse4" in sys.argv:
     copy_sse4()
 
 
 # Copy SSE3 build files
 def copy_sse3():
     print("\nCopying SSE3 build files\n")
-    copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'SSE3', 'build')),
-      os.path.normpath(os.path.join(cr_src_dir, 'build'))
-    )
     copy(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'SSE3', 'thor_ver')),
-      os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "SSE3", "thor_ver")),
+        os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
     )
     os.chdir(cr_src_dir)
     print("\nDownloading PGO Profiles for Windows x64\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win64 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win64 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profiles for Windows x86\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win32 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win32 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profile for V8\n")
     try_run(
-    'python3 v8/tools/builtins-pgo/download_profiles.py '
-    '--depot-tools=third_party/depot_tools --force download'
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
     )
 
 
-if '--sse3' in sys.argv:
+if "--sse3" in sys.argv:
     copy_sse3()
 
 
 # Copy SSE2 build files
 def copy_sse2():
     print("\nCopying SSE2 build files\n")
-    copy_directory(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'SSE2', 'build')),
-      os.path.normpath(os.path.join(cr_src_dir, 'build'))
-    )
     copy(
-      os.path.normpath(os.path.join(thor_src_dir, 'other', 'SSE2', 'thor_ver')),
-      os.path.normpath(os.path.join(cr_src_dir, 'out', 'thorium'))
+        os.path.normpath(os.path.join(
+            thor_src_dir, "other", "SSE2", "thor_ver")),
+        os.path.normpath(os.path.join(cr_src_dir, "out", "thorium")),
     )
     os.chdir(cr_src_dir)
     print("\nDownloading PGO Profiles for Windows x86\n")
     try_run(
-    'python3 tools/update_pgo_profiles.py --target=win32 '
-    'update --gs-url-base=chromium-optimization-profiles/pgo_profiles'
+        "python3 tools/update_pgo_profiles.py --target=win32 "
+        "update --gs-url-base=chromium-optimization-profiles/pgo_profiles"
     )
     print("\nDownloading PGO Profile for V8\n")
     try_run(
-    'python3 v8/tools/builtins-pgo/download_profiles.py '
-    '--depot-tools=third_party/depot_tools --force download'
+        "python3 v8/tools/builtins-pgo/download_profiles.py "
+        "--depot-tools=third_party/depot_tools --force download"
     )
 
 
-if '--sse2' in sys.argv:
+if "--sse2" in sys.argv:
     copy_sse2()
+
+    print("\nPatching ANGLE for SSE2\n")
+    copy(
+        os.path.normpath(
+            os.path.join(thor_src_dir, "other", "SSE2", "angle-lockfree.patch")
+        ),
+        os.path.normpath(os.path.join(
+            cr_src_dir, "third_party", "angle", "src")),
+    )
+
+    # Change directory to angle_dir and run commands
+    angle_dir = os.path.join(cr_src_dir, "third_party", "angle", "src")
+    os.chdir(angle_dir)
+    try_run(f"git apply --reject angle-lockfree.patch")
 
 
 print("\nDone!\n")

--- a/win_scripts/tot.py
+++ b/win_scripts/tot.py
@@ -30,37 +30,37 @@ def try_run(command):
 def display_help():
     print(f"\nScript to Rebase/Sync Chromium repo to Tip of Tree.\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 
 # Set chromium/src dir from Windows environment variable
-cr_src_dir = os.getenv('CR_DIR', r'C:/src/chromium/src')
+cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
 
 
 def main():
 
     print("\nScript to Rebase/Sync Chromium repo to Tip of Tree.\n")
     print(
-        f"Rebasing/Syncing to `origin/main` and running hooks in {cr_src_dir}\n"
-    )
+        f"Rebasing/Syncing to `origin/main` and running hooks in {cr_src_dir}\n")
 
     # Change directory to cr_src_dir and run commands
     os.chdir(cr_src_dir)
 
     # Commands to run
     commands = [
-        'cd v8 && git restore . && git clean -ffd',
-        'cd third_party/devtools-frontend/src && git restore . && git clean -ffd',
-        'cd third_party/ffmpeg && git restore . && git clean -ffd',
-        'git checkout -f origin/main',
-        'git clean -ffd',
-        'git rebase-update',
-        'git fetch --tags',
-        'gclient sync --with_branch_heads --with_tags -f -R -D',
-        'git clean -ffd',
-        'gclient runhooks'
+        "cd v8 && git restore . && git clean -ffd",
+        "cd third_party/devtools-frontend/src && git restore . && git clean -ffd",
+        "cd third_party/ffmpeg && git restore . && git clean -ffd",
+        "git checkout -f origin/main",
+        "git clean -ffd",
+        "git rebase-update",
+        "git fetch --tags",
+        "gclient sync --with_branch_heads --with_tags -f -R -D",
+        "git clean -ffd",
+        "gclient runhooks",
     ]
 
     # Run each command with error handling

--- a/win_scripts/trunk.py
+++ b/win_scripts/trunk.py
@@ -37,13 +37,14 @@ def safe_rmtree(path):
 def display_help():
     print(f"\nScript to Rebase/Sync the Chromium repo.\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 
 # Set chromium/src dir from Windows environment variable
-cr_src_dir = os.getenv('CR_DIR', r'C:/src/chromium/src')
+cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
 # Thorium-specific directory that need to be deleted
 pak_dir = os.path.normpath(os.path.join(cr_src_dir, "third_party", "pak"))
 
@@ -61,17 +62,17 @@ def main():
 
     # Commands to run
     commands = [
-        'cd v8 && git restore . && git clean -ffd',
-        'cd third_party/devtools-frontend/src && git restore . && git clean -ffd',
-        'cd third_party/ffmpeg && git restore . && git clean -ffd',
-        'git checkout -f origin/main',
-        'git clean -ffd',
-        'git clean -ffd',
-        'git rebase-update',
-        'git fetch --tags',
-        'gclient sync --with_branch_heads --with_tags -f -R -D',
-        'git clean -ffd',
-        'gclient runhooks'
+        "cd v8 && git restore . && git clean -ffd",
+        "cd third_party/devtools-frontend/src && git restore . && git clean -ffd",
+        "cd third_party/ffmpeg && git restore . && git clean -ffd",
+        "git checkout -f origin/main",
+        "git clean -ffd",
+        "git clean -ffd",
+        "git rebase-update",
+        "git fetch --tags",
+        "gclient sync --with_branch_heads --with_tags -f -R -D",
+        "git clean -ffd",
+        "gclient runhooks",
     ]
 
     # Run each command with error handling

--- a/win_scripts/upstream_version.py
+++ b/win_scripts/upstream_version.py
@@ -7,7 +7,6 @@ sysroot. At the same time, download only the PGO file for win64.
 """
 
 import os
-import shutil
 import subprocess
 import sys
 
@@ -31,17 +30,18 @@ def display_help():
     print(f"\nScript to check out Chromium tag of current Thorium version.\n")
     print(f"\nNOTE: You may need to run trunk.py before using this script\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 
 # Set chromium/src dir from Windows environment variable
-cr_src_dir = os.getenv('CR_DIR', r'C:/src/chromium/src')
+cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
 
 
 # Set cr_ver
-cr_ver = "128.0.6613.194"
+cr_ver = "138.0.7204.300"
 
 
 print(f"\nCurrent Chromium version is: {cr_ver}\n")
@@ -50,14 +50,14 @@ print(f"\nNOTE: Checking out tags/{cr_ver} in {cr_src_dir}\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
 
-try_run(f'git checkout -f tags/{cr_ver}')
+try_run(f"git checkout -f tags/{cr_ver}")
 
 # Commands to run
 commands = [
-    'git clean -ffd',
-    'git clean -ffd',
-    'gclient sync --with_branch_heads --with_tags -f -R -D',
-    'gclient runhooks',
+    "git clean -ffd",
+    "git clean -ffd",
+    "gclient sync --with_branch_heads --with_tags -f -R -D",
+    "git clean -ffd",
 ]
 
 # Run each command with error handling

--- a/win_scripts/version.py
+++ b/win_scripts/version.py
@@ -40,19 +40,21 @@ def display_help():
     print(f"\nScript to check out Chromium tag of current Thorium version.\n")
     print(f"\nNOTE: You may need to run trunk.py before using this script\n")
 
-if '--help' in sys.argv:
+
+if "--help" in sys.argv:
     display_help()
     sys.exit(0)
 
 
 # Set chromium/src dir from Windows environment variable
-cr_src_dir = os.getenv('CR_DIR', r'C:/src/chromium/src')
+cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
 # Set Thorium dir from Windows environment variable
-thor_src_dir = os.path.expandvars(os.getenv('THOR_DIR', r'%USERPROFILE%/thorium'))
+thor_src_dir = os.path.expandvars(
+    os.getenv("THOR_DIR", r"%USERPROFILE%/thorium"))
 
 
 # Set thor_ver
-thor_ver = "128.0.6613.194"
+thor_ver = "138.0.7204.300"
 
 
 print(f"\nCurrent Thorium version is: {thor_ver}\n")
@@ -61,28 +63,31 @@ print(f"\nNOTE: Checking out tags/{thor_ver} in {cr_src_dir}\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
 
-try_run(f'git checkout -f tags/{thor_ver}')
+try_run(f"git checkout -f tags/{thor_ver}")
 
 # Copy files using shutil
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'thorium-libjxl/src/DEPS')),
-    os.path.normpath(os.path.join(cr_src_dir, 'DEPS'))
+    os.path.normpath(os.path.join(thor_src_dir, "thorium-libjxl/src/DEPS")),
+    os.path.normpath(os.path.join(cr_src_dir, "DEPS")),
 )
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'thorium-libjxl/src/.gitmodules')),
-    os.path.normpath(os.path.join(cr_src_dir, '.gitmodules'))
+    os.path.normpath(os.path.join(
+        thor_src_dir, "thorium-libjxl/src/.gitmodules")),
+    os.path.normpath(os.path.join(cr_src_dir, ".gitmodules")),
 )
 copy(
-    os.path.normpath(os.path.join(thor_src_dir, 'thorium-libjxl/src/third_party/.gitignore')),
-    os.path.normpath(os.path.join(cr_src_dir, 'third_party/.gitignore'))
+    os.path.normpath(
+        os.path.join(thor_src_dir, "thorium-libjxl/src/third_party/.gitignore")
+    ),
+    os.path.normpath(os.path.join(cr_src_dir, "third_party/.gitignore")),
 )
 
 # Commands to run
 commands = [
-    'git clean -ffd',
-    'git clean -ffd',
-    'gclient sync --with_branch_heads --with_tags -f -R -D',
-    'gclient runhooks',
+    "git clean -ffd",
+    "git clean -ffd",
+    "gclient sync --with_branch_heads --with_tags -f -R -D",
+    "git clean -ffd",
 ]
 
 # Run each command with error handling


### PR DESCRIPTION
1. Reformatted Python code using Microsoft's
official VS Code extension Black Formatter.

https://github.com/microsoft/vscode-black-formatter

2. Fixed an issue in `setup.py` where PGO files
were not downloaded when no arguments were passed
(i.e., when building the AVX version).

3. `clean.py` now better identifies and cleans up
PGO files and output directories after
compilation.

4. `make_portable_win.py` now supports copying the
installer directly from the build output directory
and renaming the portable archive according to
Thorium's naming convention.