### PR TITLE
Change references to the renamed create_dmg and get_repo.sh files.

### DIFF
--- a/build_mac.sh
+++ b/build_mac.sh
@@ -44,7 +44,7 @@ buildShell () {
 	cat ~/thorium/logos/thorium_logo_ascii_art.txt &&
 	printf "\n" &&
 	
-	printf "${GRE}${bold}Build Completed. ${YEL}${bold}You can now run \'./build_dmg.sh\', and copy the Thorium Shell.app out.\n" &&
+	printf "${GRE}${bold}Build Completed. ${YEL}${bold}You can now run \'./create_dmg.sh\', and copy the Thorium Shell.app out.\n" &&
 	tput sgr0
 }
 case $1 in
@@ -77,5 +77,5 @@ printf "\n" &&
 cat ~/thorium/logos/thorium_logo_ascii_art.txt &&
 printf "\n" &&
 
-printf "${GRE}${bold}Build Completed. ${YEL}${bold}You can now run \'./build_dmg.sh\'\n" &&
+printf "${GRE}${bold}Build Completed. ${YEL}${bold}You can now run \'./create_dmg.sh\'\n" &&
 tput sgr0

--- a/docs/BUILDING_MAC.md
+++ b/docs/BUILDING_MAC.md
@@ -174,7 +174,7 @@ $ out/thorium/Thorium.app/Contents/MacOS/Thorium
 To generate a *.dmg* installation package, run (from within the Thorium repo):
 
 ```shell
-$ ./build_dmg.sh
+$ ./create_dmg.sh
 ```
 
 ### Avoiding repetitive system permissions dialogs after each build

--- a/infra/set_exec.sh
+++ b/infra/set_exec.sh
@@ -33,7 +33,7 @@ sudo chmod -v +x g &&
 
 sudo chmod -v +x build_android.sh &&
 
-sudo chmod -v +x build_dmg.sh &&
+sudo chmod -v +x create_dmg.sh &&
 
 sudo chmod -v +x build_mac.sh &&
 
@@ -57,13 +57,13 @@ sudo chmod -v +x version.sh &&
 
 sudo chmod -v +x upstream_version.sh &&
 
+sudo chmod -v +x get_repo.sh &&
+
 sudo chmod -v +x infra/arch-prerequisites.sh &&
 
 sudo chmod -v +x infra/fetch_api_keys.sh &&
 
 sudo chmod -v +x infra/fix_libaom.sh &&
-
-sudo chmod -v +x infra/install_deps.sh &&
 
 sudo chmod -v +x infra/build_dmg_cr.sh &&
 


### PR DESCRIPTION
Change references to the renamed `create_dmg` and `get_repo.sh` files.

Done due to the local renaming from these commits:

```
commit c4ee4f2b9a02d3f35a14c1776c424a6b8dd73042
Author: Alexander Frick <Alex313031@gmail.com>
Date:   Tue Feb 20 00:17:40 2024 -0600

     minor 206 uprev for ThOS

  ...
  build_dmg.sh => create_dmg.sh    |   0
  ...

commit bcc54f7bda9c5efe7ba4d6529b04eaa6e183a911
Author: Alexander Frick <Alex313031@gmail.com>
Date:   Tue Aug 20 14:26:49 2024 -0500

     update wrappers, scripts, and Th24 UI

  ...
  infra/install_deps.sh => get_repo.sh              |    0
  ...
```
