### PR TITLE
Fix typos in docs/

### DIFF
--- a/docs/ABOUT_GN_ARGS.md
+++ b/docs/ABOUT_GN_ARGS.md
@@ -6,7 +6,7 @@ __google_api_key__ "" &#35; Set Google API Key. Unset in public Thorium reposito
 
 __google_default_client_id__ "" &#35; Set the Client ID. Unset in public Thorium repository.
 
-__google_default_client_secret__ "" &#35; Set the Client Secret. All three must be set to use Google Sync, Translate, etc. Unset in public Thorium repository. You can make and set your own by following https://www.chromium.org/developers/how-tos/api-keys/. &#35; NOTE: Thorium contributers, contact me for access to the private API_KEYS repo.
+__google_default_client_secret__ "" &#35; Set the Client Secret. All three must be set to use Google Sync, Translate, etc. Unset in public Thorium repository. You can make and set your own by following https://www.chromium.org/developers/how-tos/api-keys/. &#35; NOTE: Thorium contributors, contact me for access to the private API_KEYS repo.
 
 ## __Experimental__
 
@@ -86,7 +86,7 @@ __v8_enable_turbofan__ &#35;  Enable the TurboFan optimizing JS compiler compone
 
 __v8_enable_wasm_simd256_revec__ &#35; Whether WebAssembly is compiled with 256-bit long SIMD code. Set to true in Thorium for performance.
 
-__use_v8_context_snapshot__ &#35; Build a seperate .bin file with V8's function templates and V8 contexts. Enabled in Thorium.
+__use_v8_context_snapshot__ &#35; Build a separate .bin file with V8's function templates and V8 contexts. Enabled in Thorium.
 
 __blink_symbol_level__ &#35; Set the symbol level for Blink (Chromium's rendering engine.), regardless of symbol_level value. Options are: 0, 1, and 2. Set to 0 for performance.
 

--- a/docs/ABOUT_RELEASES.md
+++ b/docs/ABOUT_RELEASES.md
@@ -14,7 +14,7 @@ The first was called MMX (Multi-Media EXtensions). Then came SSE, SSE2, SSE3, SS
 
 More info on SIMD and how the optimizations work in Thorium can be found on the site > https://thorium.rocks/optimizations
 
-However, they have to be built in (compiled in) to a program, and they are backwards, but not forwards compatible. Furthurmore, your CPU *must* support a given SIMD 
+However, they have to be built in (compiled in) to a program, and they are backwards, but not forwards compatible. Furthermore, your CPU *must* support a given SIMD 
 level or else the browser will crash.
 
 For example, a CPU that is capable of AVX is capable of all the SSE instructions, and so could run either an SSE3 or AVX release, but would get better 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -64,7 +64,7 @@ dependencies.
 $ fetch --nohooks chromium
 ```
 
-The `--nohooks` flag is ommitted on other platforms, we just use it on linux to explicitly run the hooks
+The `--nohooks` flag is omitted on other platforms, we just use it on linux to explicitly run the hooks
 later, after installing the prerequisites.
 `fetch` and `repo` are used to download, rebase, and sync all Google repositories, including Chromium, ChromiumOS, 
 Android, Fuchsia, Infra, Monorail, GN, etc.
@@ -123,7 +123,7 @@ to enable Sync.
 
 First, we need to run `./trunk.sh` (in the root of the Thorium repo.) This will Rebase/Sync the Chromium repo, and revert it to stock Chromium.  
 It will also fetch all the tags/branches, which is needed for the version.sh script.
-It should be used before every seperate build. See the [Updating](#updating) section.
+It should be used before every separate build. See the [Updating](#updating) section.
 
 __IMPORTANT__
 This will update and sync the sources to the latest revision (tip of tree) and ensure you have all the version tags.
@@ -137,7 +137,7 @@ Chromium and Thorium use [Ninja](https://ninja-build.org) as their main build to
 a tool called [GN](https://gn.googlesource.com/gn/+/refs/heads/main/README.md)
 to generate `.ninja` files in the build output directory. You can create any number of *build directories*
 with different configurations. Create the build output directory by running:
-- Run `gn args out/thorium` and the contents of '[args.gn](https://github.com/Alex313031/thorium/blob/main/args.gn)' in the root of this repo should be copy/pasted into the editor. Note that for Windows, Mac, ChromiumOS, or Android there are seperate &#42;_args.gn files for those platforms. *--Include your api keys here at the top or leave blank, and edit the last line to point to the actual path and file name of '&#42;.profdata'* 
+- Run `gn args out/thorium` and the contents of '[args.gn](https://github.com/Alex313031/thorium/blob/main/args.gn)' in the root of this repo should be copy/pasted into the editor. Note that for Windows, Mac, ChromiumOS, or Android there are separate &#42;_args.gn files for those platforms. *--Include your api keys here at the top or leave blank, and edit the last line to point to the actual path and file name of '&#42;.profdata'* 
 - For more info about args.gn, read the [ABOUT_GN_ARGS.md](https://github.com/Alex313031/thorium/blob/main/infra/DEBUG/ABOUT_GN_ARGS.md) file.
 - '[infra/args.list](https://github.com/Alex313031/thorium/blob/main/infra/args.list)' contains an alphabetical list with descriptions of all possible build arguments; [gn_args.list](https://github.com/Alex313031/thorium/blob/main/infra/gn_args.list) gives a similar list but with the flags in args.gn added.
 

--- a/docs/CMDLINE_FLAGS_LIST.md
+++ b/docs/CMDLINE_FLAGS_LIST.md
@@ -99,7 +99,7 @@ Format: Condition ## Explanation ##
 
 --allow-silent-push ##	Allows Web Push notifications that do not show a notification. ##
 
---allow-sync-xhr-in-page-dimissal ##	Allow a page to send synchronus XHR during its unloading. TODO(https://crbug.com/1003101): Remove this in Chrome 88. ##
+--allow-sync-xhr-in-page-dimissal ##	Allow a page to send synchronous XHR during its unloading. TODO(https://crbug.com/1003101): Remove this in Chrome 88. ##
 
 --allow-third-party-modules[1] ##	Allows third party modules to inject by disabling the BINARY\_SIGNATURE mitigation policy on Win10+. Also has other effects in ELF. ##
 
@@ -615,7 +615,7 @@ Format: Condition ## Explanation ##
 
 --disable-canvas-aa ##	Disable antialiasing on 2d canvas. ##
 
---disable-checker-imaging ##	Disabled defering all image decodes to the image decode service, ignoring DecodingMode preferences specified on PaintImage. ##
+--disable-checker-imaging ##	Disabled deferring all image decodes to the image decode service, ignoring DecodingMode preferences specified on PaintImage. ##
 
 --disable-checking-optimization-guide-user-permissions ##	No description ##
 
@@ -1245,7 +1245,7 @@ Format: Condition ## Explanation ##
 
 --enable-potentially-annoying-security-features ##	Enables a number of potentially annoying security features (strict mixed content mode, powerful feature restrictions, etc.) ##
 
---enable-precise-memory-info ##	Make the values returned to window.performance.memory more granular and more up to date in shared worker. Without this flag, the memory information is still available, but it is bucketized and updated less frequently. This flag also applys to workers. ##
+--enable-precise-memory-info ##	Make the values returned to window.performance.memory more granular and more up to date in shared worker. Without this flag, the memory information is still available, but it is bucketized and updated less frequently. This flag also applies to workers. ##
 
 --enable-prefer-compositing-to-lcd-text ##	Enable the creation of compositing layers when it would prevent LCD text. ##
 
@@ -1321,7 +1321,7 @@ Format: Condition ## Explanation ##
 
 --enable-unsafe-webgpu ##	No description ##
 
---enable-use-zoom-for-dsf ##	Enable the mode that uses zooming to implment device scale factor behavior. ##
+--enable-use-zoom-for-dsf ##	Enable the mode that uses zooming to implement device scale factor behavior. ##
 
 --enable-user-metrics[6] ##	Enable user metrics from within the installer. ##
 
@@ -1833,7 +1833,7 @@ Format: Condition ## Explanation ##
 
 --max-active-webgl-contexts ##	Allows user to override maximum number of active WebGL contexts per renderer process. ##
 
---max-decoded-image-size-mb ##	Sets the maximium decoded image size limitation. ##
+--max-decoded-image-size-mb ##	Sets the maximum decoded image size limitation. ##
 
 --max-file-size ##	Limit the size of files the scanning engine is allowed to open. ##
 
@@ -1947,7 +1947,7 @@ Format: Condition ## Explanation ##
 
 --no-experiments ##	Disables all experiments set on about:flags. Does not disable about:flags itself. Useful if an experiment makes chrome crash at startup: One can start chrome with --no-experiments, disable the problematic lab at about:flags and then restart chrome without this switch again. ##
 
---no-first-run ##	Skip First Run tasks, whether or not it's actually the First Run. Overridden by kForceFirstRun. This does not drop the First Run sentinel and thus doesn't prevent first run from occuring the next time chrome is launched without this flag. ##
+--no-first-run ##	Skip First Run tasks, whether or not it's actually the First Run. Overridden by kForceFirstRun. This does not drop the First Run sentinel and thus doesn't prevent first run from occurring the next time chrome is launched without this flag. ##
 
 --no-initial-navigation ##	Stops new Shell objects from navigating to a default url. ##
 
@@ -2231,7 +2231,7 @@ Format: Condition ## Explanation ##
 
 --remote-debugging-socket-name[7] ##	Enables remote debug over HTTP on the specified socket name. ##
 
---remote-debugging-targets ##	Porvides a list of addresses to discover DevTools remote debugging targets. The format is <host>:<port>,...,<host>:port. ##
+--remote-debugging-targets ##	Provides a list of addresses to discover DevTools remote debugging targets. The format is <host>:<port>,...,<host>:port. ##
 
 --remove-scan-only-uws ##	Allow the engine to remove UwS that isn't marked cleanable. For testing only. ##
 
@@ -2409,7 +2409,7 @@ Format: Condition ## Explanation ##
 
 --skia-font-cache-limit-mb ##	Specifies the max number of bytes that should be used by the skia font cache. If the cache needs to allocate more, skia will purge previous entries. ##
 
---skia-resource-cache-limit-mb ##	Specifies the max number of bytes that should be used by the skia resource cache. The previous entries are purged from the cache when the memory useage exceeds this limit. ##
+--skia-resource-cache-limit-mb ##	Specifies the max number of bytes that should be used by the skia resource cache. The previous entries are purged from the cache when the memory usage exceeds this limit. ##
 
 --slow-down-compositing-scale-factor ##	Re-draw everything multiple times to simulate a much slower machine. Give a slow down factor to cause renderer to take that many times longer to complete, such as --slow-down-compositing-scale-factor=2. ##
 
@@ -2447,7 +2447,7 @@ Format: Condition ## Explanation ##
 
 --storage-pressure-notification-interval ##	Interval, in minutes, used for storage pressure notification throttling. Useful for developers testing applications that might use non-trivial amounts of disk space. ##
 
---structured-metrics-disabled ##	Disable structured metrics logging of cros actions. ##
+--structured-metrics-disabled ##	Disable structured metrics logging of CrOS actions. ##
 
 --stub ##	No description ##
 
@@ -2725,7 +2725,7 @@ Format: Condition ## Explanation ##
 
 --video\_capture ##	No description ##
 
---virtual-time-budget ##	If set the system waits the specified number of virtual milliseconds before deeming the page to be ready. For determinism virtual time does not advance while there are pending network fetches (i.e no timers will fire). Once all network fetches have completed, timers fire and if the system runs out of virtual time is fastforwarded so the next timer fires immediatley, until the specified virtual time budget is exhausted. ##
+--virtual-time-budget ##	If set the system waits the specified number of virtual milliseconds before deeming the page to be ready. For determinism virtual time does not advance while there are pending network fetches (i.e no timers will fire). Once all network fetches have completed, timers fire and if the system runs out of virtual time is fastforwarded so the next timer fires immediately, until the specified virtual time budget is exhausted. ##
 
 --vmodule ##	Gives the per-module maximal V-logging levels to override the value given by --v. E.g. "my\_module=2,foo\*=3" would change the logging level for all code in source files "my\_module.\*" and "foo\*.\*" ("-inl" suffixes are also disregarded for this matching). Any pattern containing a forward or backward slash will be tested against the whole pathname and not just the module. E.g., "\*/foo/bar/\*=2" would change the logging level for all code in source files under a "foo/bar" directory. ##
 

--- a/docs/TH24.md
+++ b/docs/TH24.md
@@ -2,9 +2,9 @@
 
 Google started an initiative to refresh and redesign the UI of Chromium/Chrome 
 at the end of 2022 with [this commit](https://source.chromium.org/chromium/chromium/src/+/9bebadaa2a460012b124ba795587b1603bb3f6a2). 
-The previous redesign of the UI that occured in 2017 with M70 was called GM2. 
+The previous redesign of the UI that occurred in 2017 with M70 was called GM2. 
 This new design was given the codename Chrome Refresh 2023. It is also sometimes 
-referred to in the code and comments as Cr23, CR23, or GM3 (meaning sucessor to GM2).
+referred to in the code and comments as Cr23, CR23, or GM3 (meaning successor to GM2).
 See more about Chrome Refresh 2023 [Here](ss).
 
 It made for a really ugly, harder to use UI. Everything is super rounded and spaced out, 

--- a/docs/WIN_CROSS_BUILD_INSTRUCTIONS.txt
+++ b/docs/WIN_CROSS_BUILD_INSTRUCTIONS.txt
@@ -1,4 +1,4 @@
-# These are instruction for cross building Thorium for Windows, on Linux. Preliminary file for @gz83, to be eventually migrated to a Wiki with building instructions for all paltforms.
+# These are instruction for cross building Thorium for Windows, on Linux. Preliminary file for @gz83, to be eventually migrated to a Wiki with building instructions for all platforms.
 ## Copyright (c) 2024 Alex313031
 
 ## In general, this document follows information from > https://chromium.googlesource.com/chromium/src.git/+/HEAD/docs/win_cross.md and https://chromium.googlesource.com/chromium/src/+/main/docs/linux/build_instructions.md

--- a/docs/WIN_INSTRUCTIONS.txt
+++ b/docs/WIN_INSTRUCTIONS.txt
@@ -1,4 +1,4 @@
-# These are instruction for building Thorium for Windows, natively on Windows. Preliminary file for @gz83, to be eventually migrated to a Wiki with building instructions for all paltforms.
+# These are instruction for building Thorium for Windows, natively on Windows. Preliminary file for @gz83, to be eventually migrated to a Wiki with building instructions for all platforms.
 ## Copyright (c) 2024 Alex313031
 
 ## Preparatory setup


### PR DESCRIPTION
Using https://github.com/crate-ci/typos