### PR TITLE
Backport some patches and fix a crash caused by the disable-aero flag

### DIFF
--- a/other/fix_dangling_pointer_tooltip.patch
+++ b/other/fix_dangling_pointer_tooltip.patch
@@ -1,0 +1,201 @@
+From 75384c7f9e55413450742f4c926534da7721e6cd Mon Sep 17 00:00:00 2001
+From: Ho Cheung <hocheung@chromium.org>
+Date: Thu, 8 Jan 2026 07:17:36 -0800
+Subject: [PATCH] [corewm] Fix dangling pointer in TooltipStateManager
+
+Make TooltipStateManager observe tooltip_parent_window_ lifecycle
+to prevent UAF. Pointers are now cleared immediately in
+OnWindowDestroying() before the window is destroyed.
+
+Bug: 40285438
+Change-Id: I5018bf2c80df7c38021af988ae27c68b5b6c62e8
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7396650
+Reviewed-by: Dana Fried <dfried@chromium.org>
+Commit-Queue: Aaron Teo <hocheung@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1566277}
+---
+ ui/views/corewm/tooltip_controller.cc    |  4 +++-
+ ui/views/corewm/tooltip_state_manager.cc | 28 +++++++++++++++++++----
+ ui/views/corewm/tooltip_state_manager.h  | 29 +++++++++++++++++-------
+ 3 files changed, 48 insertions(+), 13 deletions(-)
+
+diff --git a/ui/views/corewm/tooltip_controller.cc b/ui/views/corewm/tooltip_controller.cc
+index 1b614c56609a6..996e094a9e201 100644
+--- a/ui/views/corewm/tooltip_controller.cc
++++ b/ui/views/corewm/tooltip_controller.cc
+@@ -5,6 +5,7 @@
+ #include "ui/views/corewm/tooltip_controller.h"
+ 
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #include <string_view>
+ #include <utility>
+@@ -511,7 +512,8 @@ void TooltipController::SetObservedWindow(aura::Window* target) {
+ }
+ 
+ bool TooltipController::IsTooltipIdUpdateNeeded() const {
+-  return state_manager_->tooltip_id() != wm::GetTooltipId(observed_window_);
++  return state_manager_->tooltip_id() !=
++         reinterpret_cast<std::uintptr_t>(wm::GetTooltipId(observed_window_));
+ }
+ 
+ bool TooltipController::IsTooltipTextUpdateNeeded() const {
+diff --git a/ui/views/corewm/tooltip_state_manager.cc b/ui/views/corewm/tooltip_state_manager.cc
+index a193519150450..89a776081a934 100644
+--- a/ui/views/corewm/tooltip_state_manager.cc
++++ b/ui/views/corewm/tooltip_state_manager.cc
+@@ -5,6 +5,7 @@
+ #include "ui/views/corewm/tooltip_state_manager.h"
+ 
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #include <utility>
+ #include <vector>
+@@ -48,6 +49,19 @@ int TooltipStateManager::GetMaxWidth(const gfx::Point& location) const {
+   return tooltip_->GetMaxWidth(location);
+ }
+ 
++void TooltipStateManager::SetTooltipParentWindow(aura::Window* window) {
++  if (tooltip_parent_window_ == window) {
++    return;
++  }
++
++  window_observation_.Reset();
++  tooltip_parent_window_ = window;
++
++  if (window) {
++    window_observation_.Observe(window);
++  }
++}
++
+ void TooltipStateManager::HideAndReset() {
+   // Hide any open tooltips.
+   will_hide_tooltip_timer_.Stop();
+@@ -55,8 +69,8 @@ void TooltipStateManager::HideAndReset() {
+ 
+   // Cancel pending tooltips and reset states.
+   will_show_tooltip_timer_.Stop();
+-  tooltip_id_ = nullptr;
+-  tooltip_parent_window_ = nullptr;
++  tooltip_id_ = 0;
++  SetTooltipParentWindow(nullptr);
+ }
+ 
+ void TooltipStateManager::Show(aura::Window* window,
+@@ -68,9 +82,9 @@ void TooltipStateManager::Show(aura::Window* window,
+   HideAndReset();
+ 
+   position_ = position;
+-  tooltip_id_ = wm::GetTooltipId(window);
++  tooltip_id_ = reinterpret_cast<std::uintptr_t>(wm::GetTooltipId(window));
+   tooltip_text_ = tooltip_text;
+-  tooltip_parent_window_ = window;
++  SetTooltipParentWindow(window);
+   tooltip_trigger_ = trigger;
+ 
+   std::u16string truncated_text =
+@@ -147,4 +161,10 @@ void TooltipStateManager::StartWillShowTooltipTimer(
+   }
+ }
+ 
++void TooltipStateManager::OnWindowDestroying(aura::Window* window) {
++  if (tooltip_parent_window_ == window) {
++    HideAndReset();
++  }
++}
++
+ }  // namespace views::corewm
+diff --git a/ui/views/corewm/tooltip_state_manager.h b/ui/views/corewm/tooltip_state_manager.h
+index 7d8e0564a39af..172731cad670b 100644
+--- a/ui/views/corewm/tooltip_state_manager.h
++++ b/ui/views/corewm/tooltip_state_manager.h
+@@ -5,13 +5,17 @@
+ #ifndef UI_VIEWS_COREWM_TOOLTIP_STATE_MANAGER_H_
+ #define UI_VIEWS_COREWM_TOOLTIP_STATE_MANAGER_H_
+ 
++#include <stdint.h>
++
+ #include <map>
+ #include <memory>
+ #include <string>
+ 
+ #include "base/memory/raw_ptr.h"
++#include "base/scoped_observation.h"
+ #include "base/time/time.h"
+ #include "base/timer/timer.h"
++#include "ui/aura/window_observer.h"
+ #include "ui/gfx/geometry/point.h"
+ #include "ui/views/corewm/tooltip.h"
+ #include "ui/views/corewm/tooltip_controller.h"
+@@ -34,12 +38,12 @@ class TooltipControllerTestHelper;
+ // TooltipStateManager separates the state handling from the events handling of
+ // the TooltipController. It is in charge of updating the tooltip state and
+ // keeping track of it.
+-class VIEWS_EXPORT TooltipStateManager {
++class VIEWS_EXPORT TooltipStateManager : public aura::WindowObserver {
+  public:
+   explicit TooltipStateManager(std::unique_ptr<Tooltip> tooltip);
+   TooltipStateManager(const TooltipStateManager&) = delete;
+   TooltipStateManager& operator=(const TooltipStateManager&) = delete;
+-  ~TooltipStateManager();
++  ~TooltipStateManager() override;
+ 
+   void AddObserver(wm::TooltipObserver* observer);
+   void RemoveObserver(wm::TooltipObserver* observer);
+@@ -61,9 +65,9 @@ class VIEWS_EXPORT TooltipStateManager {
+             const base::TimeDelta show_delay,
+             const base::TimeDelta hide_delay);
+ 
+-  // Returns the `tooltip_id_`, which corresponds to the pointer of the view on
+-  // which the tooltip was last added.
+-  const void* tooltip_id() const { return tooltip_id_; }
++  // Returns the `tooltip_id_`, which corresponds to the pointer value of the
++  // view on which the tooltip was last added.
++  std::uintptr_t tooltip_id() const { return tooltip_id_; }
+   // Returns the `tooltip_text_`, which corresponds to the last value the
+   // tooltip got updated to.
+   const std::u16string& tooltip_text() const { return tooltip_text_; }
+@@ -79,9 +83,15 @@ class VIEWS_EXPORT TooltipStateManager {
+   void UpdatePositionIfNeeded(const gfx::Point& position,
+                               TooltipTrigger trigger);
+ 
++  // aura::WindowObserver:
++  void OnWindowDestroying(aura::Window* window) override;
++
+  private:
+   friend class test::TooltipControllerTestHelper;
+ 
++  // Sets the tooltip parent window and manages observation.
++  void SetTooltipParentWindow(aura::Window* window);
++
+   // Called once the `will_show_tooltip_timer_` fires to show the tooltip.
+   void ShowNow(const std::u16string& trimmed_text,
+                const base::TimeDelta hide_delay);
+@@ -105,9 +115,8 @@ class VIEWS_EXPORT TooltipStateManager {
+ 
+   std::unique_ptr<Tooltip> tooltip_;
+ 
+-  // The pointer to the view for which the tooltip is set.
+-  // TODO(crbug.com/40285438) - Fix this dangling pointer.
+-  raw_ptr<const void, DanglingUntriaged> tooltip_id_ = nullptr;
++  // The pointer value of the view for which the tooltip is set.
++  std::uintptr_t tooltip_id_ = 0;
+ 
+   // The text value used at the last tooltip update.
+   std::u16string tooltip_text_;
+@@ -122,6 +131,10 @@ class VIEWS_EXPORT TooltipStateManager {
+   base::OneShotTimer will_hide_tooltip_timer_;
+   base::OneShotTimer will_show_tooltip_timer_;
+ 
++  // Observes the tooltip parent window to detect destruction.
++  base::ScopedObservation<aura::Window, aura::WindowObserver>
++      window_observation_{this};
++
+   // WeakPtrFactory to use for callbacks.
+   base::WeakPtrFactory<TooltipStateManager> weak_factory_{this};
+ };
+-- 
+2.51.0
+

--- a/other/fix_disable_aero_crash.patch
+++ b/other/fix_disable_aero_crash.patch
@@ -1,0 +1,31 @@
+From f9fce2f1f8abbb0bc72750be3756f4f8c96b4ed3 Mon Sep 17 00:00:00 2001
+From: Ho Cheung <hocheung@chromium.org>
+Date: Mon, 12 Jan 2026 22:12:16 +0800
+Subject: [PATCH] [win] Fix crash when changing color scheme with disable-aero
+ flag enabled
+
+PerformDwmTransition() requires system-drawn frames but was being called
+unconditionally in FrameTypeChanged(). Add IsFrameSystemDrawn() guard to
+prevent crash when frame mode is CUSTOM_DRAWN.
+
+Change-Id: I835656945ac22a46ddc227f07cbf058b90f2cb56
+---
+ ui/views/win/hwnd_message_handler.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
+index 1a8943c86cb1b..1f70a23bfa8a1 100644
+--- a/ui/views/win/hwnd_message_handler.cc
++++ b/ui/views/win/hwnd_message_handler.cc
+@@ -930,7 +930,7 @@ void HWNDMessageHandler::FrameTypeChanged() {
+   if (!custom_window_region_.is_valid() && IsFrameSystemDrawn()) {
+     dwm_transition_desired_ = true;
+   }
+-  if (!dwm_transition_desired_ || !IsFullscreen()) {
++  if ((!dwm_transition_desired_ || !IsFullscreen()) && IsFrameSystemDrawn()) {
+     PerformDwmTransition();
+   }
+ }
+-- 
+2.51.0
+

--- a/other/fix_getupdatesprocessor_crash.patch
+++ b/other/fix_getupdatesprocessor_crash.patch
@@ -1,0 +1,91 @@
+From 750190caa7c309af0d630b3a58d4c47c44680cb1 Mon Sep 17 00:00:00 2001
+From: Marc Treib <treib@chromium.org>
+Date: Thu, 23 Oct 2025 08:46:31 -0700
+Subject: [PATCH] Sync GetUpdatesProcessor: Remove two invalid NOTREACHED()s
+
+Two NOTREACHED()s in this class (or its helper functions) relied on data
+from the server, which means they weren't actually valid.
+
+This CL replaces them by appropriate logs and runtime errors, and also
+adds a histogram to track for which data types this happens.
+
+Bug: 451606786
+Change-Id: I318a12dfdfbf48cb87d64f2428898c00e244cb02
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7077902
+Reviewed-by: Rushan Suleymanov <rushans@google.com>
+Commit-Queue: Marc Treib <treib@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1534371}
+---
+ .../sync/engine/get_updates_processor.cc       | 18 ++++++++++++++++--
+ .../histograms/metadata/sync/histograms.xml    | 11 +++++++++++
+ 2 files changed, 27 insertions(+), 2 deletions(-)
+
+diff --git a/components/sync/engine/get_updates_processor.cc b/components/sync/engine/get_updates_processor.cc
+index da73fa5027da6..e1a1459533b48 100644
+--- a/components/sync/engine/get_updates_processor.cc
++++ b/components/sync/engine/get_updates_processor.cc
+@@ -12,6 +12,7 @@
+ #include <vector>
+ 
+ #include "base/logging.h"
++#include "base/metrics/histogram_functions.h"
+ #include "base/trace_event/trace_event.h"
+ #include "components/sync/base/data_type.h"
+ #include "components/sync/engine/cycle/status_controller.h"
+@@ -91,7 +92,9 @@ void PartitionUpdatesByType(const sync_pb::GetUpdatesResponse& gu_response,
+   for (const sync_pb::SyncEntity& update : gu_response.entries()) {
+     DataType type = GetDataTypeFromSpecifics(update.specifics());
+     if (!IsRealDataType(type)) {
+-      NOTREACHED() << "Received update with invalid type.";
++      DLOG(WARNING)
++          << "Received update for invalid or unspecified type, ignoring.";
++      continue;
+     }
+ 
+     auto it = updates_by_type->find(type);
+@@ -319,8 +322,19 @@ SyncerError GetUpdatesProcessor::ProcessResponse(
+   TypeToIndexMap progress_index_by_type;
+   PartitionProgressMarkersByType(gu_response, gu_types,
+                                  &progress_index_by_type);
++  // Verify that the response actually contained a progress marker for each
++  // requested data type. Note that `PartitionProgressMarkersByType()` will drop
++  // progress markers for types that weren't requested, so just comparing the
++  // counts is enough.
+   if (gu_types.size() != progress_index_by_type.size()) {
+-    NOTREACHED() << "Missing progress markers in GetUpdates response.";
++    for (DataType type : gu_types) {
++      if (progress_index_by_type.count(type) == 0) {
++        base::UmaHistogramEnumeration(
++            "Sync.MissingProgressMarkerInGetUpdatesResponse",
++            DataTypeHistogramValue(type));
++      }
++    }
++    return SyncerError::ProtocolViolationError();
+   }
+ 
+   TypeToIndexMap context_by_type;
+diff --git a/tools/metrics/histograms/metadata/sync/histograms.xml b/tools/metrics/histograms/metadata/sync/histograms.xml
+index e0a3a8e4740d3..08a4edf848708 100644
+--- a/tools/metrics/histograms/metadata/sync/histograms.xml
++++ b/tools/metrics/histograms/metadata/sync/histograms.xml
+@@ -1552,6 +1552,17 @@ chromium-metrics-reviews@google.com.
+   </summary>
+ </histogram>
+ 
++<histogram name="Sync.MissingProgressMarkerInGetUpdatesResponse"
++    enum="SyncDataTypes" expires_after="2026-10-01">
++  <owner>rushans@google.com</owner>
++  <owner>treib@chromium.org</owner>
++  <owner>src/components/sync/OWNERS</owner>
++  <summary>
++    Logged when the GetUpdates response didn't contain a progress marker for an
++    expected/requested data type. Recorded once per missing data type.
++  </summary>
++</histogram>
++
+ <histogram name="Sync.ModelLoadManager.LoadModelsElapsedTime" units="ms"
+     expires_after="2025-09-23">
+   <owner>ankushkush@google.com</owner>
+-- 
+2.51.0
+

--- a/setup.sh
+++ b/setup.sh
@@ -102,6 +102,9 @@ patchThor () {
 	cp -v other/thorium_webui.patch ${CR_SRC_DIR}/ &&
 	cp -v other/partalloc.patch ${CR_SRC_DIR}/ &&
 	cp -v other/skia_scale.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_getupdatesprocessor_crash.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_dangling_pointer_tooltip.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_disable_aero_crash.patch ${CR_SRC_DIR}/ &&
 
 	printf "\n" &&
 	printf "${YEL}Patching FFMPEG for HEVC...${c0}\n" &&
@@ -145,7 +148,11 @@ patchThor () {
 	git apply --reject ./thorium_webui.patch &&
 	printf "${YEL}partalloc and Skia fixes...${c0}\n" &&
 	git apply --reject ./partalloc.patch &&
-	git apply --reject ./skia_scale.patch
+	git apply --reject ./skia_scale.patch &&
+	printf "${YEL}some crashes fixes...${c0}\n" &&
+	git apply --reject ./fix_getupdatesprocessor_crash.patch &&
+	git apply --reject ./fix_dangling_pointer_tooltip.patch &&
+	git apply --reject ./fix_disable_aero_crash.patch
 }
 [ -f ${CR_SRC_DIR}/fix-policy-templates.patch ] || patchThor;
 

--- a/win_scripts/setup.py
+++ b/win_scripts/setup.py
@@ -142,6 +142,11 @@ patches = [
     "other/mini_installer.patch",
     "other/open_in_same_tab.patch",
     "other/thorium_webui.patch",
+    "other/partalloc.patch",
+    "other/skia_scale.patch",
+    "other/fix_getupdatesprocessor_crash.patch",
+    "other/fix_dangling_pointer_tooltip.patch",
+    "other/fix_disable_aero_crash.patch",
 ]
 for patch in patches:
     relative_path = patch.replace("other/", "", 1)
@@ -201,16 +206,22 @@ os.chdir(cr_src_dir)
 try_run(f"git apply --reject mini_installer.patch")
 
 
-print("\nPatching for open_in_same_tab\n")
+print("\nApplying other Misc. patches...\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
 try_run(f"git apply --reject open_in_same_tab.patch")
+try_run(f"git apply --reject thorium_webui.patch")
 
 
-print("\nPatching for thorium_webui\n")
+print("\nApplying performance and crash fixes patches...\n")
 # Change directory to cr_src_dir and run commands
 os.chdir(cr_src_dir)
-try_run(f"git apply --reject thorium_webui.patch")
+try_run(f"git apply --reject partalloc.patch")
+try_run(f"git apply --reject skia_scale.patch")
+try_run(f"git apply --reject fix_getupdatesprocessor_crash.patch")
+try_run(f"git apply --reject fix_dangling_pointer_tooltip.patch")
+try_run(f"git apply --reject fix_disable_aero_crash.patch")
+
 
 print("\nCopying other files to out/thorium\n")
 # Copying additional files


### PR DESCRIPTION
We ported some patches from upstream to downstream to fix some crashes and resolved crashes caused by using the disable-aero flag.

Causes of crashes due to using the disable-aero flag and solutions:

PerformDwmTransition() requires system-drawn frames but was being called unconditionally in FrameTypeChanged(). Add IsFrameSystemDrawn() guard to prevent crash when frame mode is CUSTOM_DRAWN.

@Alex313031 PTAL