### PR TITLE
Update Windows build versions and PGO profile

### DIFF
--- a/infra/portable/make_portable_win.py
+++ b/infra/portable/make_portable_win.py
@@ -78,7 +78,7 @@ def extract_and_copy_files(installer_name):
 
 
 def zip_files(installer_name):
-    version = "130.0.6723.174"
+    version = "138.0.7204.303"
 
     if "AVX2" in installer_name:
         zip_filename = f"Thorium_AVX2_{version}.zip"

--- a/other/AVX2/win_AVX2_args.gn
+++ b/other/AVX2/win_AVX2_args.gn
@@ -83,4 +83,4 @@ use_thin_lto = true
 thin_lto_enable_optimizations = true
 enable_rust = true
 chrome_pgo_phase = 2
-pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1753677344-c8349fe206a87b8e97766e5b8696e67842aa2b93-1e2bdfc47c96567e08feb2c83034ae7a2d413b12.profdata"
+pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1755537225-62a3943dd3ff0fa79d4dde2190852455c7c6ee5b-ece5e2a86bfb109c00e1f5c17d249778e86b4c13.profdata"

--- a/other/AVX512/win_AVX512_args.gn
+++ b/other/AVX512/win_AVX512_args.gn
@@ -83,4 +83,4 @@ use_thin_lto = true
 thin_lto_enable_optimizations = true
 enable_rust = true
 chrome_pgo_phase = 2
-pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1753677344-c8349fe206a87b8e97766e5b8696e67842aa2b93-1e2bdfc47c96567e08feb2c83034ae7a2d413b12.profdata"
+pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1755537225-62a3943dd3ff0fa79d4dde2190852455c7c6ee5b-ece5e2a86bfb109c00e1f5c17d249778e86b4c13.profdata"

--- a/other/SSE3/win64_SSE3_args.gn
+++ b/other/SSE3/win64_SSE3_args.gn
@@ -83,4 +83,4 @@ use_thin_lto = true
 thin_lto_enable_optimizations = true
 enable_rust = true
 chrome_pgo_phase = 2
-pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1753677344-c8349fe206a87b8e97766e5b8696e67842aa2b93-1e2bdfc47c96567e08feb2c83034ae7a2d413b12.profdata"
+pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1755537225-62a3943dd3ff0fa79d4dde2190852455c7c6ee5b-ece5e2a86bfb109c00e1f5c17d249778e86b4c13.profdata"

--- a/other/SSE4.1/win64_SSE4.1_args.gn
+++ b/other/SSE4.1/win64_SSE4.1_args.gn
@@ -83,4 +83,4 @@ use_thin_lto = true
 thin_lto_enable_optimizations = true
 enable_rust = true
 chrome_pgo_phase = 2
-pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1753677344-c8349fe206a87b8e97766e5b8696e67842aa2b93-1e2bdfc47c96567e08feb2c83034ae7a2d413b12.profdata"
+pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1755537225-62a3943dd3ff0fa79d4dde2190852455c7c6ee5b-ece5e2a86bfb109c00e1f5c17d249778e86b4c13.profdata"

--- a/other/SSE4.2/win64_SSE4.2_args.gn
+++ b/other/SSE4.2/win64_SSE4.2_args.gn
@@ -83,4 +83,4 @@ use_thin_lto = true
 thin_lto_enable_optimizations = true
 enable_rust = true
 chrome_pgo_phase = 2
-pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1753677344-c8349fe206a87b8e97766e5b8696e67842aa2b93-1e2bdfc47c96567e08feb2c83034ae7a2d413b12.profdata"
+pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1755537225-62a3943dd3ff0fa79d4dde2190852455c7c6ee5b-ece5e2a86bfb109c00e1f5c17d249778e86b4c13.profdata"

--- a/win_args.gn
+++ b/win_args.gn
@@ -83,4 +83,4 @@ use_thin_lto = true
 thin_lto_enable_optimizations = true
 enable_rust = true
 chrome_pgo_phase = 2
-pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1753677344-c8349fe206a87b8e97766e5b8696e67842aa2b93-1e2bdfc47c96567e08feb2c83034ae7a2d413b12.profdata"
+pgo_data_path = "/home/alex/chromium/src/chrome/build/pgo_profiles/chrome-win64-7204-1755537225-62a3943dd3ff0fa79d4dde2190852455c7c6ee5b-ece5e2a86bfb109c00e1f5c17d249778e86b4c13.profdata"

--- a/win_scripts/setup.py
+++ b/win_scripts/setup.py
@@ -166,6 +166,9 @@ copy(
         os.path.join(thor_src_dir, "other",
                      "add-hevc-ffmpeg-decoder-parser.patch")
     ),
+    os.path.normpath(os.path.join(cr_src_dir, "third_party", "ffmpeg")),
+)
+copy(
     os.path.normpath(
         os.path.join(thor_src_dir, "other", "change-libavcodec-header.patch")
     ),

--- a/win_scripts/upstream_version.py
+++ b/win_scripts/upstream_version.py
@@ -41,7 +41,7 @@ cr_src_dir = os.getenv("CR_DIR", r"C:/src/chromium/src")
 
 
 # Set cr_ver
-cr_ver = "138.0.7204.301"
+cr_ver = "138.0.7204.303"
 
 
 print(f"\nCurrent Chromium version is: {cr_ver}\n")

--- a/win_scripts/version.py
+++ b/win_scripts/version.py
@@ -54,7 +54,7 @@ thor_src_dir = os.path.expandvars(
 
 
 # Set thor_ver
-thor_ver = "138.0.7204.301"
+thor_ver = "138.0.7204.303"
 
 
 print(f"\nCurrent Thorium version is: {thor_ver}\n")


### PR DESCRIPTION
Bump Chromium/Thorium/portable versions to 138.0.7204.303, refresh PGO profile paths for Win args, and adjust Windows setup to copy the ffmpeg directory before applying patches.

@Alex313031 PTAL