### PR TITLE
Fixed debug build and a crash in the download shelf

### DIFF
--- a/other/fix_absl_undefined_symbol.patch
+++ b/other/fix_absl_undefined_symbol.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/abseil-cpp/symbols_x64_dbg.def b/third_party/abseil-cpp/symbols_x64_dbg.def
+index e49e9a82d1c5a..6c7a3102abac7 100644
+--- a/third_party/abseil-cpp/symbols_x64_dbg.def
++++ b/third_party/abseil-cpp/symbols_x64_dbg.def
+@@ -263,7 +263,6 @@ EXPORTS
+     ??$?8PEBQEAVLogSink@absl@@PEAPEAV01@@__Cr@std@@YA_NAEBV?$__wrap_iter@PEBQEAVLogSink@absl@@@01@AEBV?$__wrap_iter@PEAPEAVLogSink@absl@@@01@@Z
+     ??$?8PEBUConversionItem@ParsedFormatBase@str_format_internal@absl@@@__Cr@std@@YA_NAEBV?$__wrap_iter@PEBUConversionItem@ParsedFormatBase@str_format_internal@absl@@@01@0@Z
+     ??$?8PEBUUnrecognizedFlag@absl@@@__Cr@std@@YA_NAEBV?$__wrap_iter@PEBUUnrecognizedFlag@absl@@@01@0@Z
+-    ??$?8UUnrecognizedFlag@absl@@U01@@__Cr@std@@YA_NAEBV?$allocator@UUnrecognizedFlag@absl@@@01@0@Z
+     ??$?8V?$InlinedVector@UPayload@status_internal@absl@@$00V?$allocator@UPayload@status_internal@absl@@@__Cr@std@@@absl@@U?$default_delete@V?$InlinedVector@UPayload@status_internal@absl@@$00V?$allocator@UPayload@status_internal@absl@@@__Cr@std@@@absl@@@__Cr@std@@@__Cr@std@@YA_NAEBV?$unique_ptr@V?$InlinedVector@UPayload@status_internal@absl@@$00V?$allocator@UPayload@status_internal@absl@@@__Cr@std@@@absl@@U?$default_delete@V?$InlinedVector@UPayload@status_internal@absl@@$00V?$allocator@UPayload@status_internal@absl@@@__Cr@std@@@absl@@@__Cr@std@@@01@$$T@Z
+     ??$?8VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@__Cr@std@@@__Cr@std@@YA_NAEBV?$unique_ptr@VZoneInfoSource@cctz@time_internal@absl@@U?$default_delete@VZoneInfoSource@cctz@time_internal@absl@@@__Cr@std@@@01@$$T@Z
+     ??$?BV?$vector@V?$basic_string@DU?$char_traits@D@__Cr@std@@V?$allocator@D@23@@__Cr@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@__Cr@std@@V?$allocator@D@23@@__Cr@std@@@23@@__Cr@std@@$0A@@?$Splitter@VByChar@absl@@UAllowEmpty@2@V?$basic_string_view@DU?$char_traits@D@__Cr@std@@@__Cr@std@@@strings_internal@absl@@QEBA?AV?$vector@V?$basic_string@DU?$char_traits@D@__Cr@std@@V?$allocator@D@23@@__Cr@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@__Cr@std@@V?$allocator@D@23@@__Cr@std@@@23@@__Cr@std@@XZ

--- a/setup.sh
+++ b/setup.sh
@@ -108,6 +108,7 @@ patchThor () {
 	cp -v other/fix_disable_aero_crash.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_file_dialog_crash.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_wayland_scale_crash.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_absl_undefined_symbol.patch ${CR_SRC_DIR}/ &&
 
 	printf "\n" &&
 	printf "${YEL}Patching FFMPEG for HEVC...${c0}\n" &&
@@ -152,6 +153,8 @@ patchThor () {
 	git apply --reject ./thorium_webui.patch &&
 	printf "${YEL}partalloc fix...${c0}\n" &&
 	git apply --reject ./partalloc.patch &&
+	printf "${YEL}absl undefined symbol fix...${c0}\n" &&
+	git apply --reject ./fix_absl_undefined_symbol.patch &&
 	printf "${YEL}some crashes fixes...${c0}\n" &&
 	git apply --reject ./fix_profile_selector_crash.patch &&
 	git apply --reject ./fix_getupdatesprocessor_crash.patch &&

--- a/src/chrome/browser/download/download_ui_controller.cc
+++ b/src/chrome/browser/download/download_ui_controller.cc
@@ -92,7 +92,13 @@ class DownloadShelfUIControllerDelegate
  public:
   // |profile| is required to outlive DownloadShelfUIControllerDelegate.
   explicit DownloadShelfUIControllerDelegate(Profile* profile)
-      : profile_(profile) {}
+      : profile_(profile) {
+    // Match DownloadBubbleUIControllerDelegate behavior: in incognito mode,
+    // prompt for download location.
+    if (profile_->IsOffTheRecord()) {
+      profile_->GetPrefs()->SetBoolean(prefs::kPromptForDownload, true);
+    }
+  }
   ~DownloadShelfUIControllerDelegate() override = default;
 
  private:

--- a/win_scripts/setup.py
+++ b/win_scripts/setup.py
@@ -150,6 +150,7 @@ patches = [
     "other/fix_file_dialog_crash.patch",
     "other/fix_wayland_scale_crash.patch",
     "other/restore_download_shelf.patch",
+    "other/fix_absl_undefined_symbol.patch",
 ]
 for patch in patches:
     relative_path = patch.replace("other/", "", 1)
@@ -220,6 +221,7 @@ print("\nApplying other Misc. patches...\n")
 os.chdir(cr_src_dir)
 try_run(f"git apply --reject open_in_same_tab.patch")
 try_run(f"git apply --reject thorium_webui.patch")
+try_run(f"git apply --reject fix_absl_undefined_symbol.patch")
 
 
 print("\nApplying performance and crash fixes patches...\n")


### PR DESCRIPTION
1. std::allocator::operator== is marked _LIBCPP_HIDE_FROM_ABI (inline-only) in libc++. The compiler now correctly inlines it, so no export definition is generated.

2. DownloadShelfUIControllerDelegate didn't set kPromptForDownload = true for incognito, unlike DownloadBubbleUIControllerDelegate. This allowed userscripts to auto-trigger CrxInstaller, which crashes on incognito profiles.

https://github.com/Alex313031/thorium/issues/1137

@Alex313031 PTAL