### PR TITLE
Change WebRTCIPHandlingPolicy to DefaultPublicAndPrivateInterfaces

### DIFF
--- a/src/chrome/browser/ui/browser_ui_prefs.cc
+++ b/src/chrome/browser/ui/browser_ui_prefs.cc
@@ -125,7 +125,7 @@ void RegisterBrowserUserPrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 false);
 #endif
   registry->RegisterStringPref(prefs::kWebRTCIPHandlingPolicy,
-                               blink::kWebRTCIPHandlingDisableNonProxiedUdp);
+                               blink::kWebRTCIPHandlingDefaultPublicAndPrivateInterfaces);
   registry->RegisterListPref(prefs::kWebRTCIPHandlingUrl, base::Value::List());
   registry->RegisterStringPref(prefs::kWebRTCUDPPortRange, std::string());
   registry->RegisterBooleanPref(prefs::kWebRtcEventLogCollectionAllowed, false);


### PR DESCRIPTION
The `DisableNonProxiedUdp` setting is too strict, which negatively impacts the user experience to some extent. Perhaps we need to strike a balance between user experience and privacy protection.

https://github.com/Alex313031/thorium/issues/1113

@Alex313031 