### PR TITLE
Fix Touch Emulator Double Tap Zoom, crash and update ntp patch

### DIFF
--- a/other/fix_setting_popover_invoker_crash.patch
+++ b/other/fix_setting_popover_invoker_crash.patch
@@ -1,0 +1,56 @@
+From 76c78f62312def1b5af7e275a1e978814f7f2d0e Mon Sep 17 00:00:00 2001
+From: Mason Freed <masonf@chromium.org>
+Date: Wed, 18 Jun 2025 10:33:23 -0700
+Subject: [PATCH] Remove CHECK in setting popover invoker
+
+The prior check was possible to hit, fairly easily, by simply calling
+`showPopover()` on two popovers with the same source. That case seems
+to work just fine, so this CL removes the CHECK, and adds a crash
+test.
+
+Fixed: 424151801
+Change-Id: Icf1b28c2d6d9bc9e733b7a95243d929637a331f5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6648487
+Commit-Queue: Di Zhang <dizhangg@chromium.org>
+Reviewed-by: Di Zhang <dizhangg@chromium.org>
+Auto-Submit: Mason Freed <masonf@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1475695}
+---
+ third_party/blink/renderer/core/dom/invoker_data.h    |  2 --
+ .../html/semantics/popovers/popover-source-crash.html | 11 +++++++++++
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+ create mode 100644 third_party/blink/web_tests/external/wpt/html/semantics/popovers/popover-source-crash.html
+
+diff --git a/third_party/blink/renderer/core/dom/invoker_data.h b/third_party/blink/renderer/core/dom/invoker_data.h
+index bed7946722efc..44d85d660a969 100644
+--- a/third_party/blink/renderer/core/dom/invoker_data.h
++++ b/third_party/blink/renderer/core/dom/invoker_data.h
+@@ -35,8 +35,6 @@ class InvokerData final : public GarbageCollected<InvokerData>,
+ 
+   HTMLElement* GetInvokedPopover() const { return invoked_popover_; }
+   void SetInvokedPopover(HTMLElement* popover) {
+-    CHECK_NE(!popover, !invoked_popover_)
+-        << "Invoked popover must be cleared before being reset";
+     CHECK(!popover || popover->popoverOpen());
+     invoked_popover_ = popover;
+   }
+diff --git a/third_party/blink/web_tests/external/wpt/html/semantics/popovers/popover-source-crash.html b/third_party/blink/web_tests/external/wpt/html/semantics/popovers/popover-source-crash.html
+new file mode 100644
+index 0000000000000..11dcac6253fe5
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/html/semantics/popovers/popover-source-crash.html
+@@ -0,0 +1,11 @@
++<!DOCTYPE html>
++
++<button popovertarget=auto></button>
++<div popover=auto id=auto></div>
++<div popover=hint id=hint></div>
++
++<script>
++const button = document.querySelector('button');
++document.querySelector('#auto').showPopover({source: button});
++document.querySelector('#hint').showPopover({source: button});
++</script>
+-- 
+2.47.3
+

--- a/other/fix_touch_emulator_double_tap_zoom.patch
+++ b/other/fix_touch_emulator_double_tap_zoom.patch
@@ -1,0 +1,43 @@
+From 192fb17a609084a1ac0c2fa8e18ffa26e180b6a8 Mon Sep 17 00:00:00 2001
+From: Philip Pfaffe <pfaffe@chromium.org>
+Date: Tue, 22 Jul 2025 08:13:32 -0700
+Subject: [PATCH] Unconditionally call touch emulator for mobile-optimized
+ state changes
+
+crrev.com/c/6094203 called the touch emulator conditionally, only when
+the mobile-optimized state actually changes. This caused a regression
+with mobile emulation.
+
+Fixed: 409577163
+Change-Id: I8e59abc1d7e12a0c8fa828a5d546acf3c30cb3d5
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6771797
+Commit-Queue: Philip Pfaffe <pfaffe@chromium.org>
+Commit-Queue: Aman Verma <amanvr@google.com>
+Reviewed-by: Aman Verma <amanvr@google.com>
+Auto-Submit: Philip Pfaffe <pfaffe@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1490172}
+---
+ content/browser/renderer_host/render_widget_host_impl.cc | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/content/browser/renderer_host/render_widget_host_impl.cc b/content/browser/renderer_host/render_widget_host_impl.cc
+index 252edf0bb40ba..d37d560a9b6a2 100644
+--- a/content/browser/renderer_host/render_widget_host_impl.cc
++++ b/content/browser/renderer_host/render_widget_host_impl.cc
+@@ -3834,10 +3834,9 @@ void RenderWidgetHostImpl::OnRenderFrameMetadataChangedAfterActivation(
+ 
+   if (mobile_optimized_state_changed) {
+     input_router()->NotifySiteIsMobileOptimized(is_mobile_optimized_);
+-    if (auto* touch_emulator =
+-            GetTouchEmulator(/*create_if_necessary=*/false)) {
+-      touch_emulator->SetDoubleTapSupportForPageEnabled(!is_mobile_optimized_);
+-    }
++  }
++  if (auto* touch_emulator = GetTouchEmulator(/*create_if_necessary=*/false)) {
++    touch_emulator->SetDoubleTapSupportForPageEnabled(!is_mobile_optimized_);
+   }
+ 
+   // TODO(danakj): Can this method be called during WebContents destruction?
+-- 
+2.47.3
+

--- a/other/remove_discovery_module_from_ntp.patch
+++ b/other/remove_discovery_module_from_ntp.patch
@@ -1,16 +1,5 @@
-From bfb08f0ab9a320a76bddfc36ee358cb6174c6626 Mon Sep 17 00:00:00 2001
-From: Ho Cheung
-Date: Thu, 13 Feb 2025 10:19:37 +0800
-Subject: [PATCH] [Android] Remove-discovery-module-from-NTP
-
----
- .../res/layout/new_tab_page_feed_v2_expandable_header.xml    | 5 +++--
- .../java/res/layout/new_tab_page_multi_feed_header.xml       | 5 +++--
- components/feed/core/shared_prefs/pref_names.cc              | 4 ++--
- 3 files changed, 8 insertions(+), 6 deletions(-)
-
 diff --git a/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml b/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml
-index 93a3d036f9c49..942100187320b 100644
+index 93a3d036f9c49..32ac344a6074d 100644
 --- a/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml
 +++ b/chrome/browser/feed/android/java/res/layout/new_tab_page_feed_v2_expandable_header.xml
 @@ -1,6 +1,6 @@
@@ -32,7 +21,7 @@ index 93a3d036f9c49..942100187320b 100644
      <RelativeLayout
          tools:ignore="RelativeOverlap"
 diff --git a/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml b/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml
-index dfa33369d2db4..3246e8689ded7 100644
+index dfa33369d2db4..c57394177e3cd 100644
 --- a/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml
 +++ b/chrome/browser/feed/android/java/res/layout/new_tab_page_multi_feed_header.xml
 @@ -1,6 +1,6 @@
@@ -54,7 +43,7 @@ index dfa33369d2db4..3246e8689ded7 100644
    <LinearLayout
        android:id="@+id/main_content"
 diff --git a/components/feed/core/shared_prefs/pref_names.cc b/components/feed/core/shared_prefs/pref_names.cc
-index 50f880e715489..ce7c2695ab09f 100644
+index 50f880e715489..673472daf56ec 100644
 --- a/components/feed/core/shared_prefs/pref_names.cc
 +++ b/components/feed/core/shared_prefs/pref_names.cc
 @@ -1,4 +1,4 @@
@@ -72,6 +61,3 @@ index 50f880e715489..ce7c2695ab09f 100644
    registry->RegisterBooleanPref(kEnableSnippetsByDse, true);
  }
  
--- 
-2.47.1.windows.2
-

--- a/setup.sh
+++ b/setup.sh
@@ -103,16 +103,21 @@ patchThor () {
 	cp -v other/disable-privacy-sandbox.patch ${CR_SRC_DIR}/ &&
 	cp -v other/win_updater.patch ${CR_SRC_DIR}/ &&
 	cp -v other/keyboard_shortcuts.patch ${CR_SRC_DIR}/ &&
-	# Patches to remove after upstream fixes them
+	# Starting with M144, the following patches can be removed
 	cp -v other/partalloc.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_profile_selector_crash.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_getupdatesprocessor_crash.patch ${CR_SRC_DIR}/ &&
-	cp -v other/fix_dangling_pointer_tooltip.patch ${CR_SRC_DIR}/ &&
-	cp -v other/fix_disable_aero_crash.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_absl_undefined_symbol.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_file_dialog_crash.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_wayland_scale_crash.patch ${CR_SRC_DIR}/ &&
-	cp -v other/fix_absl_undefined_symbol.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_drag_and_drop_on_wayland.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_touch_emulator_double_tap_zoom.patch ${CR_SRC_DIR}/ &&
+	cp -v other/fix_setting_popover_invoker_crash.patch ${CR_SRC_DIR}/ &&
+	# Starting with M145, the following patch can be removed
+	cp -v other/fix_dangling_pointer_tooltip.patch ${CR_SRC_DIR}/ &&
+	# The following patch could not be fixed upstream because it
+	# is related to our custom flags
+	cp -v other/fix_disable_aero_crash.patch ${CR_SRC_DIR}/ &&
 
 	printf "\n" &&
 	printf "${YEL}Patching FFMPEG for HEVC...${c0}\n" &&
@@ -171,8 +176,11 @@ patchThor () {
 	git apply --reject ./fix_disable_aero_crash.patch &&
 	git apply --reject ./fix_file_dialog_crash.patch &&
 	git apply --reject ./fix_wayland_scale_crash.patch &&
+	git apply --reject ./fix_setting_popover_invoker_crash.patch &&
 	printf "${YEL}Fix Drag and Drop on wayland...${c0}\n" &&
-	git apply --reject ./fix_drag_and_drop_on_wayland.patch
+	git apply --reject ./fix_drag_and_drop_on_wayland.patch &&
+	printf "${YEL}Fix Touch Emulator Double Tap Zoom...${c0}\n" &&
+	git apply --reject ./fix_touch_emulator_double_tap_zoom.patch
 }
 [ -f ${CR_SRC_DIR}/fix-policy-templates.patch ] || patchThor;
 

--- a/win_scripts/setup.py
+++ b/win_scripts/setup.py
@@ -154,6 +154,8 @@ patches = [
     "other/restore_download_shelf.patch",
     "other/fix_absl_undefined_symbol.patch",
     "other/fix_drag_and_drop_on_wayland.patch",
+    "other/fix_touch_emulator_double_tap_zoom.patch",
+    "other/fix_setting_popover_invoker_crash.patch",
 ]
 for patch in patches:
     relative_path = patch.replace("other/", "", 1)
@@ -229,6 +231,7 @@ try_run(f"git apply --reject thorium_webui.patch")
 try_run(f"git apply --reject win_updater.patch")
 try_run(f"git apply --reject disable-privacy-sandbox.patch")
 try_run(f"git apply --reject keyboard_shortcuts.patch")
+try_run(f"git apply --reject fix_touch_emulator_double_tap_zoom.patch")
 
 
 print("\nApplying performance and crash fixes patches...\n")
@@ -243,6 +246,7 @@ try_run(f"git apply --reject fix_dangling_pointer_tooltip.patch")
 try_run(f"git apply --reject fix_disable_aero_crash.patch")
 try_run(f"git apply --reject fix_file_dialog_crash.patch")
 try_run(f"git apply --reject fix_wayland_scale_crash.patch")
+try_run(f"git apply --reject fix_setting_popover_invoker_crash.patch")
 
 
 print("\nCopying other files to out/thorium\n")


### PR DESCRIPTION
https://github.com/Alex313031/Thorium-Win/issues/406

https://github.com/Alex313031/thorium/issues/1173

At the same time, the NTP patch was updated, and clear instructions were provided on how to handle backward porting patches in subsequent versions.

@Alex313031 PTAL