### PR TITLE
Add Cromite Android extension support patches to Thorium

### DIFF
--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -65,10 +65,10 @@ Disable Captive Portals Detection > https://github.com/uazo/cromite/blob/master/
   - Made by uazo
 
 Experimental Android Extension Support Patch > https://github.com/uazo/cromite/blob/master/build/patches/Experimental-support-for-extensions-on-Android.patch
-  - Adapted for Thorium from Cromite patch
+  - Made by uazo
 
 Enable Extensions in Incognito on Android Patch > https://github.com/uazo/cromite/blob/master/build/patches/Enable-extension-in-incognito.patch
-  - Adapted for Thorium from Cromite patch
+  - Made by uazo
 
 Enable Do Not Track By Default Patch > https://github.com/GrapheneOS/Vanadium/blob/main/patches/0045-enable-dubious-Do-Not-Track-feature-by-default.patch
 

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -64,6 +64,12 @@ DNS Over HTTPS (DoH) Bare Minimum HTTP Headers Patch > https://github.com/uazo/c
 Disable Captive Portals Detection > https://github.com/uazo/cromite/blob/master/build/patches/Remove-detection-of-captive-portals.patch
   - Made by uazo
 
+Experimental Android Extension Support Patch > https://github.com/uazo/cromite/blob/master/build/patches/Experimental-support-for-extensions-on-Android.patch
+  - Adapted for Thorium from Cromite patch
+
+Enable Extensions in Incognito on Android Patch > https://github.com/uazo/cromite/blob/master/build/patches/Enable-extension-in-incognito.patch
+  - Adapted for Thorium from Cromite patch
+
 Enable Do Not Track By Default Patch > https://github.com/GrapheneOS/Vanadium/blob/main/patches/0045-enable-dubious-Do-Not-Track-feature-by-default.patch
 
 Enable Fingerprinting Protection Patch

--- a/other/enable-extension-incognito-thorium.patch
+++ b/other/enable-extension-incognito-thorium.patch
@@ -1,0 +1,1497 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Thu, 20 Nov 2025 12:53:28 +0000
+Subject: Enable extensions in incognito
+
+Full activation of incognito mode in experimental extension
+
+License: GPL-3.0-only - https://spdx.org/licenses/GPL-3.0-only.html
+---
+ .../chrome/browser/ChromeTabbedActivity.java  |   9 ++
+ .../chrome/browser/app/ChromeActivity.java    |  43 ++++++--
+ .../BaseCustomTabRootUiCoordinator.java       |   2 +
+ .../CustomTabIntentDataProvider.java          |   3 +
+ .../tabbed_mode/TabbedRootUiCoordinator.java  |   1 +
+ .../browser/tabmodel/TabModelJniBridge.java   |   4 +-
+ .../tabmodel/TabModelSelectorBase.java        |  14 +++
+ .../browser/toolbar/ToolbarManager.java       |   2 +
+ .../chrome/browser/ui/RootUiCoordinator.java  |   2 +
+ .../developer_private_functions.cc            |   3 +-
+ .../browser/extensions/extension_tab_util.cc  |   2 +-
+ .../tabmodel/IncognitoTabModelImpl.java       |  14 ++-
+ .../tabmodel/IncognitoTabModelObserver.java   |   3 +
+ .../extensions/extension_actions_bridge.cc    |  23 ++--
+ .../extensions/extension_actions_bridge.h     |   4 +-
+ .../ExtensionActionContextMenuBridge.java     |   2 +-
+ .../ui/extensions/ExtensionActionsBridge.java |  92 ++++++++++++----
+ .../ui/extensions/ExtensionsMenuBridge.java   |  70 ++++++++++--
+ .../extensions/ExtensionsToolbarBridge.java   | 101 +++++++++++++-----
+ .../android/tab_model/tab_model_jni_bridge.cc |   4 +
+ .../ExtensionActionListCoordinator.java       |  12 +++
+ .../ExtensionActionListMediator.java          |  14 ++-
+ .../ExtensionActionsUpdateHelper.java         |   3 +-
+ .../ExtensionToolbarCoordinator.java          |   3 +
+ .../ExtensionToolbarCoordinatorImpl.java      |  15 +--
+ ...MenuAndAccessControlButtonCoordinator.java |   5 +-
+ .../extensions/ExtensionsMenuCoordinator.java |   2 +
+ .../extensions/ExtensionsMenuMediator.java    |  21 ++--
+ .../browser_window/ChromeAndroidTaskImpl.java |  41 ++++++-
+ .../ChromeAndroidTaskFeature.java             |   2 +-
+ components/tabs/impl/tab_collection.cc        |  16 +++
+ components/tabs/impl/tab_strip_collection.cc  |   4 +-
+ 32 files changed, 426 insertions(+), 110 deletions(-)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+@@ -122,6 +122,7 @@ import org.chromium.chrome.browser.compositor.overlays.strip.StripLayoutHelperMa
+ import org.chromium.chrome.browser.compositor.overlays.strip.StripLayoutHelperManager.TabModelStartupInfo;
+ import org.chromium.chrome.browser.cookies.CookiesFetcher;
+ import org.chromium.chrome.browser.crypto.CipherFactory;
++import org.chromium.chrome.browser.customtabs.CustomTabActivity;
+ import org.chromium.chrome.browser.data_sharing.DataSharingIntentUtils;
+ import org.chromium.chrome.browser.data_sharing.DataSharingTabGroupUtils;
+ import org.chromium.chrome.browser.data_sharing.DataSharingTabManager;
+@@ -310,11 +311,15 @@ import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneBase;
+ import org.chromium.chrome.browser.tasks.tab_management.TabUiUtils;
+ import org.chromium.chrome.browser.tasks.tab_management.TabsSettings;
+ import org.chromium.chrome.browser.tasks.tab_management.archived_tabs_auto_delete_promo.ArchivedTabsAutoDeletePromoManager;
++import org.chromium.chrome.browser.tabmodel.IncognitoTabModelObserver;
+ import org.chromium.chrome.browser.toolbar.ToolbarIntentMetadata;
+ import org.chromium.chrome.browser.toolbar.ToolbarManager;
+ import org.chromium.chrome.browser.toolbar.extensions.ExtensionToolbarCoordinator;
+ import org.chromium.chrome.browser.toolbar.top.ToolbarControlContainer;
+ import org.chromium.chrome.browser.ui.AppLaunchDrawBlocker;
++import org.chromium.chrome.browser.ui.extensions.windowing.ExtensionWindowControllerBridge;
++import org.chromium.chrome.browser.ui.extensions.windowing.ExtensionWindowControllerBridgeFactory;
++import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTaskFeatureKey;
+ import org.chromium.chrome.browser.ui.IncognitoRestoreAppLaunchDrawBlockerFactory;
+ import org.chromium.chrome.browser.ui.RootUiCoordinator;
+ import org.chromium.chrome.browser.ui.appmenu.AppMenuPropertiesDelegate;
+@@ -4009,6 +4014,10 @@ public class ChromeTabbedActivity extends ChromeActivity implements PreAttachInt
+             }
+             RecordUserAction.record("MobileMenuRecentTabs");
+         } else if (id == R.id.extensions_menu_id) {
++            if (getCurrentTabModel().isIncognito()) {
++                CustomTabActivity.showInfoPage(this, UrlConstants.CHROME_EXTENSIONS_URL);
++                return true;
++            }
+             LoadUrlParams params =
+                     new LoadUrlParams(
+                             UrlConstants.CHROME_EXTENSIONS_URL, PageTransition.AUTO_TOPLEVEL);
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+@@ -188,6 +188,7 @@ import org.chromium.chrome.browser.tab.TabSelectionType;
+ import org.chromium.chrome.browser.tab.TabState;
+ import org.chromium.chrome.browser.tab.TabUtils;
+ import org.chromium.chrome.browser.tab_ui.TabContentManager;
++import org.chromium.chrome.browser.tabmodel.IncognitoTabModelObserver;
+ import org.chromium.chrome.browser.tabmodel.SupportedProfileType;
+ import org.chromium.chrome.browser.tabmodel.TabCreator;
+ import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
+@@ -220,6 +221,9 @@ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTaskTrackerFac
+ import org.chromium.chrome.browser.ui.device_lock.MissingDeviceLockLauncher;
+ import org.chromium.chrome.browser.ui.edge_to_edge.EdgeToEdgeController;
+ import org.chromium.chrome.browser.ui.edge_to_edge.EdgeToEdgeUtils;
++import org.chromium.chrome.browser.ui.extensions.ExtensionActionsBridge;
++import org.chromium.chrome.browser.ui.extensions.ExtensionsMenuBridge;
++import org.chromium.chrome.browser.ui.extensions.ExtensionsToolbarBridge;
+ import org.chromium.chrome.browser.ui.extensions.windowing.ExtensionWindowControllerBridge;
+ import org.chromium.chrome.browser.ui.extensions.windowing.ExtensionWindowControllerBridgeFactory;
+ import org.chromium.chrome.browser.ui.messages.snackbar.Snackbar;
+@@ -1123,18 +1127,45 @@ public abstract class ChromeActivity extends AsyncInitializationActivity
+             // TODO(crbug.com/475200706): Handle multiple profiles for mobile.
+             Profile profile = tabModelSelector.getCurrentModel().getProfile();
+             assert profile != null;
+-            chromeAndroidTask.addFeature(
+-                    new ChromeAndroidTaskFeatureKey(ExtensionWindowControllerBridge.class, profile),
+-                    () ->
+-                            ExtensionWindowControllerBridgeFactory.create(
+-                                    chromeAndroidTask, profile));
++            addFeatures(chromeAndroidTask, profile);
+ 
+             // 5. Make the ChromeAndroidTask available via OneshotSupplier.
+             mChromeAndroidTaskSupplier.set(chromeAndroidTask);
++
++            tabModelSelector.addIncognitoTabModelObserver(
++                new IncognitoTabModelObserver() {
++                    @Override
++                    public void onAssociateWithBrowserWindow() {
++                        var chromeAndroidTask = getChromeAndroidTaskSupplier().get();
++                        var profile = tabModelSelector.getModel(true).getProfile();
++                        addFeatures(chromeAndroidTask, profile);
++                    }
++
++                    @Override
++                    public void didDestroyed() {
++                    }
++                });
+         }
+     }
+ 
+-    /** Returns an {@link OneshotSupplier} for {@link ChromeAndroidTask}. */
++    private void addFeatures(ChromeAndroidTask task, Profile profile) {
++        task.addFeature(
++                new ChromeAndroidTaskFeatureKey(ExtensionWindowControllerBridge.class, profile),
++                () -> ExtensionWindowControllerBridgeFactory.create(task, profile));
++
++        task.addFeature(
++                new ChromeAndroidTaskFeatureKey(ExtensionsToolbarBridge.class, profile),
++                () -> ExtensionsToolbarBridge.create(task, profile));
++
++        task.addFeature(
++                new ChromeAndroidTaskFeatureKey(ExtensionActionsBridge.class, profile),
++                () -> ExtensionActionsBridge.create(task, profile));
++
++        task.addFeature(
++                new ChromeAndroidTaskFeatureKey(ExtensionsMenuBridge.class, profile),
++                () -> ExtensionsMenuBridge.create(task, profile));
++    }
++
+     protected final OneshotSupplier<ChromeAndroidTask> getChromeAndroidTaskSupplier() {
+         return mChromeAndroidTaskSupplier;
+     }
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabRootUiCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabRootUiCoordinator.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabRootUiCoordinator.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabRootUiCoordinator.java
+@@ -95,6 +95,7 @@ import org.chromium.chrome.browser.tab.EmptyTabObserver;
+ import org.chromium.chrome.browser.tab.RequestDesktopUtils;
+ import org.chromium.chrome.browser.tab.Tab;
+ import org.chromium.chrome.browser.tab_ui.TabContentManager;
++import org.chromium.chrome.browser.tabmodel.TabModel;
+ import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
+ import org.chromium.chrome.browser.tabmodel.TabModelSelector;
+ import org.chromium.chrome.browser.toolbar.adaptive.AdaptiveToolbarBehavior;
+@@ -128,6 +129,7 @@ import org.chromium.ui.modaldialog.ModalDialogManager;
+ 
+ import java.util.function.BooleanSupplier;
+ import java.util.function.Supplier;
++import java.util.function.Function;
+ 
+ /** A {@link RootUiCoordinator} variant that controls UI for {@link BaseCustomTabActivity}. */
+ public class BaseCustomTabRootUiCoordinator extends RootUiCoordinator {
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabIntentDataProvider.java
+@@ -341,6 +341,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
+ 
+     private final boolean mEnableUrlBarHiding;
+     private boolean mInteractWithBackground;
++    private boolean mIsExtension = false;
+     private List<CustomButtonParams> mCustomButtonParams;
+     private @Nullable Drawable mCloseButtonIcon;
+     private final boolean mIsCloseButtonEnabled;
+@@ -724,6 +725,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
+         mSideSheetRoundedCornersPosition =
+                 getActivitySideSheetRoundedCornersPositionFromIntent(intent);
+ 
++        mIsExtension = getUrlToLoad().startsWith(UrlConstants.CHROME_EXTENSIONS_URL);
+         logCustomTabFeatures(intent, colorScheme);
+         String packageName = getClientPackageNameFromSessionOrCallingActivity(mIntent, mSession);
+         RecordHistogram.recordBooleanHistogram(
+@@ -1378,6 +1380,7 @@ public class CustomTabIntentDataProvider extends BrowserServicesIntentDataProvid
+ 
+     @Override
+     public @CustomTabProfileType int getCustomTabMode() {
++        if (mIsExtension) return CustomTabProfileType.REGULAR;
+         return AlwaysIncognitoLinkInterceptor.isAlwaysIncognito()
+                 ? CustomTabProfileType.INCOGNITO
+                 : (ChromeFeatureList.sMayLaunchurlUsesSeparateStoragePartition.isEnabled()
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
+@@ -197,6 +197,7 @@ import org.chromium.chrome.browser.toolbar.adaptive.AdaptiveToolbarBehavior;
+ import org.chromium.chrome.browser.ui.RootUiCoordinator;
+ import org.chromium.chrome.browser.ui.appmenu.AppMenuBlocker;
+ import org.chromium.chrome.browser.ui.appmenu.AppMenuDelegate;
++import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+ import org.chromium.chrome.browser.ui.default_browser_promo.DefaultBrowserPromoUtils;
+ import org.chromium.chrome.browser.ui.desktop_windowing.AppHeaderCoordinator;
+ import org.chromium.chrome.browser.ui.desktop_windowing.AppHeaderUtils;
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelJniBridge.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelJniBridge.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelJniBridge.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelJniBridge.java
+@@ -132,10 +132,10 @@ public abstract class TabModelJniBridge implements TabModelInternal {
+     @Override
+     public void associateWithBrowserWindow(long nativeAndroidBrowserWindow) {
+         // Ensure this isn't set multiple times.
+-        assert mNativeAndroidBrowserWindow == 0;
++        if (nativeAndroidBrowserWindow != 0) assert mNativeAndroidBrowserWindow == 0;
+         mNativeAndroidBrowserWindow = nativeAndroidBrowserWindow;
+ 
+-        assert nativeAndroidBrowserWindow != 0;
++        // assert nativeAndroidBrowserWindow != 0;
+         TabModelJniBridgeJni.get()
+                 .associateWithBrowserWindow(mNativeTabModelJniBridge, nativeAndroidBrowserWindow);
+     }
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorBase.java b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorBase.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorBase.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabmodel/TabModelSelectorBase.java
+@@ -488,6 +488,20 @@ public abstract class TabModelSelectorBase
+         }
+     }
+ 
++    @Override
++    public void onAssociateWithBrowserWindow() {
++        for (IncognitoTabModelObserver observer : mIncognitoObservers) {
++            observer.onAssociateWithBrowserWindow();
++        }
++    }
++
++    @Override
++    public void didDestroyed() {
++        for (IncognitoTabModelObserver observer : mIncognitoObservers) {
++            observer.didDestroyed();
++        }
++    }
++
+     @Override
+     public void didBecomeEmpty() {
+         for (IncognitoTabModelObserver observer : mIncognitoObservers) {
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/toolbar/ToolbarManager.java
+@@ -139,6 +139,7 @@ import org.chromium.chrome.browser.tab.TabObscuringHandler;
+ import org.chromium.chrome.browser.tab.TabSelectionType;
+ import org.chromium.chrome.browser.tab_ui.TabContentManager;
+ import org.chromium.chrome.browser.tab_ui.TabModelDotInfo;
++import org.chromium.chrome.browser.tabmodel.TabModel;
+ import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider;
+ import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
+ import org.chromium.chrome.browser.tabmodel.TabModel;
+@@ -241,6 +242,7 @@ import org.chromium.url.GURL;
+ 
+ import java.util.List;
+ import java.util.function.Supplier;
++import java.util.function.Function;
+ 
+ import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import android.view.Gravity;
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ui/RootUiCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/ui/RootUiCoordinator.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ui/RootUiCoordinator.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ui/RootUiCoordinator.java
+@@ -154,6 +154,7 @@ import org.chromium.chrome.browser.tab.TabSelectionType;
+ import org.chromium.chrome.browser.tab_ui.RecyclerViewPosition;
+ import org.chromium.chrome.browser.tab_ui.TabContentManager;
+ import org.chromium.chrome.browser.tab_ui.TabSwitcher;
++import org.chromium.chrome.browser.tabmodel.TabModel;
+ import org.chromium.chrome.browser.tabmodel.TabCreator;
+ import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
+ import org.chromium.chrome.browser.tabmodel.TabModel;
+@@ -252,6 +253,7 @@ import org.chromium.url.GURL;
+ import java.lang.ref.WeakReference;
+ import java.util.function.BooleanSupplier;
+ import java.util.function.Supplier;
++import java.util.function.Function;
+ 
+ /**
+  * The root UI coordinator. This class will eventually be responsible for inflating and managing
+diff --git a/chrome/browser/extensions/api/developer_private/developer_private_functions.cc b/chrome/browser/extensions/api/developer_private/developer_private_functions.cc
+--- a/chrome/browser/extensions/api/developer_private/developer_private_functions.cc
++++ b/chrome/browser/extensions/api/developer_private/developer_private_functions.cc
+@@ -1745,7 +1745,8 @@ DeveloperPrivateDismissSafetyHubExtensionsMenuNotificationFunction::Run() {
+   }
+ 
+   Profile* profile = Profile::FromBrowserContext(browser_context());
+-  SafetyHubMenuNotificationServiceFactory::GetForProfile(profile)
++  if (auto* menu_notification_service_factory = SafetyHubMenuNotificationServiceFactory::GetForProfile(profile))
++    menu_notification_service_factory
+       ->DismissActiveNotificationOfModule(
+           safety_hub::SafetyHubModuleType::EXTENSIONS);
+   return RespondNow(NoArguments());
+diff --git a/chrome/browser/extensions/extension_tab_util.cc b/chrome/browser/extensions/extension_tab_util.cc
+--- a/chrome/browser/extensions/extension_tab_util.cc
++++ b/chrome/browser/extensions/extension_tab_util.cc
+@@ -1257,7 +1257,7 @@ bool ExtensionTabUtil::OpenOptionsPageFromWebContents(
+   if (!url) {
+     return false;
+   }
+-  const bool open_in_tab = ShouldOpenInTab(extension);
++  const bool open_in_tab = false; //ShouldOpenInTab(extension);
+ // Opens the url as instructed by `open_in_tab`. On android we take a different
+ // path because the `Browser` object is not available.
+ // TODO(crbug.com/441209530): Unify the path on android after browser
+diff --git a/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelImpl.java b/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelImpl.java
+--- a/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelImpl.java
++++ b/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelImpl.java
+@@ -147,8 +147,12 @@ class IncognitoTabModelImpl implements IncognitoTabModelInternal {
+             return;
+         }
+ 
++        // Disassociate
++        mDelegateModel.associateWithBrowserWindow(/*nativeAndroidBrowserWindow=*/ 0);
++        mNativeAndroidBrowserWindow = 0;
++
+         for (IncognitoTabModelObserver observer : mIncognitoObservers) {
+-            observer.didBecomeEmpty();
++            observer.didDestroyed();
+         }
+ 
+         mDelegateModel
+@@ -159,6 +163,10 @@ class IncognitoTabModelImpl implements IncognitoTabModelInternal {
+         mCurrentTabSupplier.set(null);
+         mTabCountSupplier.set(0);
+ 
++        for (IncognitoTabModelObserver observer : mIncognitoObservers) {
++            observer.didBecomeEmpty();
++        }
++
+         mDelegateModel = EmptyTabModel.getInstance(true);
+         for (Callback<TabModelInternal> delegateModelObserver : mDelegateModelObservers) {
+             delegateModelObserver.onResult(mDelegateModel);
+@@ -196,6 +204,10 @@ class IncognitoTabModelImpl implements IncognitoTabModelInternal {
+         assert mNativeAndroidBrowserWindow == 0;
+         mNativeAndroidBrowserWindow = nativeAndroidBrowserWindow;
+         mDelegateModel.associateWithBrowserWindow(nativeAndroidBrowserWindow);
++
++        for (IncognitoTabModelObserver observer : mIncognitoObservers) {
++            observer.onAssociateWithBrowserWindow();
++        }
+     }
+ 
+     @Override
+diff --git a/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelObserver.java b/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelObserver.java
+--- a/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelObserver.java
++++ b/chrome/browser/tabmodel/android/java/src/org/chromium/chrome/browser/tabmodel/IncognitoTabModelObserver.java
+@@ -33,4 +33,7 @@ public interface IncognitoTabModelObserver {
+ 
+     /** Called when the last tab of the {@link IncognitoTabModel} is closed. */
+     default void didBecomeEmpty() {}
++
++    default void onAssociateWithBrowserWindow() {}
++    default void didDestroyed() {}
+ }
+diff --git a/chrome/browser/ui/android/extensions/extension_actions_bridge.cc b/chrome/browser/ui/android/extensions/extension_actions_bridge.cc
+--- a/chrome/browser/ui/android/extensions/extension_actions_bridge.cc
++++ b/chrome/browser/ui/android/extensions/extension_actions_bridge.cc
+@@ -19,6 +19,8 @@
+ #include "extensions/browser/extension_action.h"
+ #include "extensions/browser/extension_action_manager.h"
+ #include "extensions/browser/extension_registry.h"
++#include "extensions/browser/process_manager.h"
++#include "extensions/browser/process_manager_factory.h"
+ #include "ui/color/color_provider_manager.h"
+ #include "ui/events/android/key_event_android.h"
+ #include "ui/events/event.h"
+@@ -60,10 +62,9 @@ void ExtensionActionsBridge::IconObserver::OnIconUpdated() {
+ }
+ 
+ ExtensionActionsBridge::ExtensionActionsBridge(
+-    BrowserWindowInterface* browser,
++    Profile* profile,
+     const base::android::JavaRef<jobject>& java_object)
+-    : browser_(browser),
+-      profile_(browser->GetProfile()),
++    : profile_(profile),
+       java_object_(java_object),
+       model_(ToolbarActionsModel::Get(profile_)),
+       keybinding_registry_(
+@@ -221,6 +222,16 @@ void ExtensionActionsBridge::ClearExtensionData(JNIEnv* env) {
+         install_directory, install_updacked_directory));
+ }
+ 
++void ExtensionActionsBridge::CloseBackgroundHosts(JNIEnv* env) {
++  extensions::ProcessManager* manager =
++          extensions::ProcessManagerFactory::GetForBrowserContextIfExists(profile_);
++  if (manager) {
++    manager->CloseBackgroundHosts();
++    ProcessManager::Get(profile_->GetOriginalProfile())
++            ->MaybeCreateStartupBackgroundHosts();
++  }
++}
++
+ jni_zero::ScopedJavaLocalRef<jobject>
+ ExtensionActionsBridge::HandleKeyDownEvent(
+     JNIEnv* env,
+@@ -309,11 +320,9 @@ void ExtensionActionsBridge::OnToolbarIconUpdated(
+ static int64_t JNI_ExtensionActionsBridge_Init(
+     JNIEnv* env,
+     const base::android::JavaRef<jobject>& java_object,
+-    int64_t j_browser_window_interface) {
+-  BrowserWindowInterface* browser =
+-      reinterpret_cast<BrowserWindowInterface*>(j_browser_window_interface);
++    Profile* profile) {
+   return reinterpret_cast<int64_t>(
+-      new ExtensionActionsBridge(browser, java_object));
++      new ExtensionActionsBridge(profile, java_object));
+ }
+ 
+ static bool JNI_ExtensionActionsBridge_ExtensionsEnabled(JNIEnv* env,
+diff --git a/chrome/browser/ui/android/extensions/extension_actions_bridge.h b/chrome/browser/ui/android/extensions/extension_actions_bridge.h
+--- a/chrome/browser/ui/android/extensions/extension_actions_bridge.h
++++ b/chrome/browser/ui/android/extensions/extension_actions_bridge.h
+@@ -25,7 +25,7 @@ namespace extensions {
+ // This bridge is created and owned by Java UI code.
+ class ExtensionActionsBridge : public ToolbarActionsModel::Observer {
+  public:
+-  ExtensionActionsBridge(BrowserWindowInterface* browser,
++  ExtensionActionsBridge(Profile* profile,
+                          const base::android::JavaRef<jobject>& java_object);
+   ExtensionActionsBridge(const ExtensionActionsBridge&) = delete;
+   ExtensionActionsBridge& operator=(const ExtensionActionsBridge&) = delete;
+@@ -53,6 +53,7 @@ class ExtensionActionsBridge : public ToolbarActionsModel::Observer {
+       int tab_id,
+       content::WebContents* web_contents);
+   void ClearExtensionData(JNIEnv* env);
++  void CloseBackgroundHosts(JNIEnv* env);
+   jni_zero::ScopedJavaLocalRef<jobject> HandleKeyDownEvent(
+       JNIEnv* env,
+       const ui::KeyEventAndroid& key_event);
+@@ -100,7 +101,6 @@ class ExtensionActionsBridge : public ToolbarActionsModel::Observer {
+   // Called by IconObserver to notify that the icon of an action was updated.
+   void OnToolbarIconUpdated(const ToolbarActionsModel::ActionId& action_id);
+ 
+-  const raw_ptr<BrowserWindowInterface> browser_;
+   const raw_ptr<Profile> profile_;
+   const base::android::ScopedJavaGlobalRef<jobject> java_object_;
+   const raw_ptr<ToolbarActionsModel> model_;
+diff --git a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionContextMenuBridge.java b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionContextMenuBridge.java
+--- a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionContextMenuBridge.java
++++ b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionContextMenuBridge.java
+@@ -35,8 +35,8 @@ public class ExtensionActionContextMenuBridge implements Destroyable {
+     private final @Nullable LifetimeAssert mLifetimeAssert = LifetimeAssert.create(this);
+ 
+     public ExtensionActionContextMenuBridge(
+-            ChromeAndroidTask task,
+             Profile profile,
++            ChromeAndroidTask task,
+             String actionId,
+             WebContents webContents,
+             @ContextMenuSource int contextMenuSource) {
+diff --git a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java
+--- a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java
++++ b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java
+@@ -6,6 +6,7 @@ package org.chromium.chrome.browser.ui.extensions;
+ 
+ import android.graphics.Bitmap;
+ import android.view.KeyEvent;
++import android.util.ArrayMap;
+ 
+ import androidx.annotation.VisibleForTesting;
+ 
+@@ -26,18 +27,61 @@ import org.chromium.extensions.ShowAction;
+ 
+ import java.util.Objects;
+ 
++import android.graphics.Rect;
++import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTaskFeature;
++import org.chromium.chrome.browser.tabmodel.TabModel;
++import org.chromium.base.Log;
++
+ /** A JNI bridge to interact with extension actions for the toolbar. */
+ @NullMarked
+ @JNINamespace("extensions")
+-public class ExtensionActionsBridge implements Destroyable {
++public class ExtensionActionsBridge implements ChromeAndroidTaskFeature {
+     private final @Nullable LifetimeAssert mLifetimeAssert = LifetimeAssert.create(this);
+     private long mNativeExtensionActionsBridge;
+     private final ObserverList<Observer> mObservers = new ObserverList<>();
+ 
+-    public ExtensionActionsBridge(ChromeAndroidTask task, Profile profile) {
++    private static ExtensionActionsBridge currentExtensionActionsBridge;
++    private final Profile mProfile;
++    private final ChromeAndroidTask mTask;
++
++    private ExtensionActionsBridge(ChromeAndroidTask task, Profile profile) {
++        mTask = task;
++        mProfile = profile;
++    }
++
++    @Override
++    public void onAddedToTask() {
+         mNativeExtensionActionsBridge =
+                 ExtensionActionsBridgeJni.get()
+-                        .init(this, task.getOrCreateNativeBrowserWindowPtr(profile));
++                        .init(this, mProfile);
++    }
++
++    @Override
++    public void onFeatureRemoved() {
++        destroy();
++    }
++
++    @Override
++    public void onTaskBoundsChanged(Rect newBoundsInDp) {}
++
++    @Override
++    public void onTaskFocusChanged(boolean hasFocus) {}
++
++    @Override
++    public void onTabModelSelected(ChromeAndroidTask task, TabModel tabModel) {
++        if (mTask == task && tabModel.getProfile() == mProfile) {
++            Instance().mNativeExtensionActionsBridge = mNativeExtensionActionsBridge;
++        }
++    }
++
++    public static ExtensionActionsBridge Instance() {
++        if (currentExtensionActionsBridge == null)
++            currentExtensionActionsBridge = new ExtensionActionsBridge(null, null);
++        return currentExtensionActionsBridge;
++    }
++
++    public static ExtensionActionsBridge create(ChromeAndroidTask task, Profile profile) {
++        return new ExtensionActionsBridge(task, profile);
+     }
+ 
+     /** Represents the result of handling a key event. */
+@@ -69,8 +113,8 @@ public class ExtensionActionsBridge implements Destroyable {
+         }
+     }
+ 
+-    @Override
+-    public void destroy() {
++    private void destroy() {
++        closeBackgroundHosts();
+         assert mNativeExtensionActionsBridge != 0;
+         ExtensionActionsBridgeJni.get().destroy(mNativeExtensionActionsBridge);
+         mNativeExtensionActionsBridge = 0;
+@@ -78,11 +122,11 @@ public class ExtensionActionsBridge implements Destroyable {
+     }
+ 
+     public void addObserver(Observer observer) {
+-        mObservers.addObserver(observer);
++        Instance().mObservers.addObserver(observer);
+     }
+ 
+     public void removeObserver(Observer observer) {
+-        mObservers.removeObserver(observer);
++        Instance().mObservers.removeObserver(observer);
+     }
+ 
+     /**
+@@ -91,19 +135,19 @@ public class ExtensionActionsBridge implements Destroyable {
+      * <p>If it returns false, you can install an observer to wait for initialization.
+      */
+     public boolean areActionsInitialized() {
+-        return ExtensionActionsBridgeJni.get().areActionsInitialized(mNativeExtensionActionsBridge);
++        return ExtensionActionsBridgeJni.get().areActionsInitialized(Instance().mNativeExtensionActionsBridge);
+     }
+ 
+     /** Returns a sorted list of enabled action IDs. */
+     public String[] getActionIds() {
+-        return ExtensionActionsBridgeJni.get().getActionIds(mNativeExtensionActionsBridge);
++        return ExtensionActionsBridgeJni.get().getActionIds(Instance().mNativeExtensionActionsBridge);
+     }
+ 
+     /** Returns the state of an action for a particular tab. */
+     @Nullable
+     public ExtensionAction getAction(String actionId, int tabId) {
+         return ExtensionActionsBridgeJni.get()
+-                .getAction(mNativeExtensionActionsBridge, actionId, tabId);
++                .getAction(Instance().mNativeExtensionActionsBridge, actionId, tabId);
+     }
+ 
+     /**
+@@ -121,7 +165,7 @@ public class ExtensionActionsBridge implements Destroyable {
+             float scaleFactor) {
+         return ExtensionActionsBridgeJni.get()
+                 .getActionIcon(
+-                        mNativeExtensionActionsBridge,
++                        Instance().mNativeExtensionActionsBridge,
+                         actionId,
+                         tabId,
+                         webContents,
+@@ -144,7 +188,7 @@ public class ExtensionActionsBridge implements Destroyable {
+         // should be easy for callers of this method to find the tab ID, so we ask them to pass it
+         // as an argument, even though the value is not used in production.
+         return ExtensionActionsBridgeJni.get()
+-                .runAction(mNativeExtensionActionsBridge, actionId, tabId, webContents);
++                .runAction(Instance().mNativeExtensionActionsBridge, actionId, tabId, webContents);
+     }
+ 
+     /**
+@@ -159,13 +203,13 @@ public class ExtensionActionsBridge implements Destroyable {
+     /** Handles the key down event and returns the result. */
+     public HandleKeyEventResult handleKeyDownEvent(KeyEvent event) {
+         return ExtensionActionsBridgeJni.get()
+-                .handleKeyDownEvent(mNativeExtensionActionsBridge, event);
++                .handleKeyDownEvent(Instance().mNativeExtensionActionsBridge, event);
+     }
+ 
+     @CalledByNative
+     @VisibleForTesting
+     public void onActionAdded(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionAdded(actionId);
+         }
+     }
+@@ -173,7 +217,7 @@ public class ExtensionActionsBridge implements Destroyable {
+     @CalledByNative
+     @VisibleForTesting
+     public void onActionRemoved(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionRemoved(actionId);
+         }
+     }
+@@ -181,7 +225,7 @@ public class ExtensionActionsBridge implements Destroyable {
+     @CalledByNative
+     @VisibleForTesting
+     public void onActionUpdated(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionUpdated(actionId);
+         }
+     }
+@@ -189,7 +233,7 @@ public class ExtensionActionsBridge implements Destroyable {
+     @CalledByNative
+     @VisibleForTesting
+     public void onActionModelInitialized() {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionModelInitialized();
+         }
+     }
+@@ -197,7 +241,7 @@ public class ExtensionActionsBridge implements Destroyable {
+     @CalledByNative
+     @VisibleForTesting
+     public void onPinnedActionsChanged() {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onPinnedActionsChanged();
+         }
+     }
+@@ -205,7 +249,7 @@ public class ExtensionActionsBridge implements Destroyable {
+     @CalledByNative
+     @VisibleForTesting
+     public void onActionIconUpdated(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionIconUpdated(actionId);
+         }
+     }
+@@ -242,14 +286,18 @@ public class ExtensionActionsBridge implements Destroyable {
+     }
+ 
+     public void clearExtensionData() {
+-        ExtensionActionsBridgeJni.get().clearExtensionData(mNativeExtensionActionsBridge);
++        ExtensionActionsBridgeJni.get().clearExtensionData(Instance().mNativeExtensionActionsBridge);
++    }
++
++    private void closeBackgroundHosts() {
++        ExtensionActionsBridgeJni.get().closeBackgroundHosts(mNativeExtensionActionsBridge);
+     }
+ 
+     @NativeMethods
+     public interface Natives {
+         boolean extensionsEnabled(@JniType("Profile*") Profile profile);
+ 
+-        long init(ExtensionActionsBridge bridge, long browserWindowInterfacePtr);
++        long init(ExtensionActionsBridge bridge, @JniType("Profile*") Profile profile);
+ 
+         void destroy(long nativeExtensionActionsBridge);
+ 
+@@ -281,6 +329,8 @@ public class ExtensionActionsBridge implements Destroyable {
+ 
+         void clearExtensionData(long nativeExtensionActionsBridge);
+ 
++        void closeBackgroundHosts(long nativeExtensionActionsBridge);
++
+         HandleKeyEventResult handleKeyDownEvent(
+                 long nativeExtensionActionsBridge,
+                 @JniType("ui::KeyEventAndroid") KeyEvent keyEvent);
+diff --git a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsMenuBridge.java b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsMenuBridge.java
+--- a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsMenuBridge.java
++++ b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsMenuBridge.java
+@@ -16,23 +16,75 @@ import org.chromium.build.annotations.Nullable;
+ import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+ 
++import android.graphics.Rect;
++import android.util.ArrayMap;
++import java.util.Map;
++import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTaskFeature;
++import org.chromium.chrome.browser.tabmodel.TabModel;
++import org.chromium.base.Log;
++
+ /** A JNI bridge that provides native extensions menu data to the Java UI. */
+ @NullMarked
+ @JNINamespace("extensions")
+-public class ExtensionsMenuBridge implements Destroyable {
++public class ExtensionsMenuBridge implements ChromeAndroidTaskFeature {
+     private final @Nullable LifetimeAssert mLifetimeAssert = LifetimeAssert.create(this);
+     private long mNativeExtensionsMenuDelegateAndroid;
+-    private final Observer mObserver;
++    private Observer mObserver;
++
++    private static ExtensionsMenuBridge currentExtensionsMenuBridge;
++    private final Map<ChromeAndroidTask, Observer> mObservers = new ArrayMap<>();
++    private final ChromeAndroidTask mTask;
++    private final Profile mProfile;
++
++    private ExtensionsMenuBridge(ChromeAndroidTask task, Profile profile) {
++        mObserver = null;
++        mProfile = profile;
++        mTask = task;
++    }
++
++    public static ExtensionsMenuBridge Instance() {
++        if (currentExtensionsMenuBridge == null)
++            currentExtensionsMenuBridge = new ExtensionsMenuBridge(null, null);
++        return currentExtensionsMenuBridge;
++    }
++
++    public static ExtensionsMenuBridge create(ChromeAndroidTask task, Profile profile) {
++        return new ExtensionsMenuBridge(task, profile);
++    }
++
++    public void setObserver(ChromeAndroidTask task, Observer observer) {
++        Instance().mObservers.put(task, observer);
++        Instance().mObserver = observer;
++    }
+ 
+-    public ExtensionsMenuBridge(ChromeAndroidTask task, Profile profile, Observer observer) {
+-        mObserver = observer;
++    @Override
++    public void onAddedToTask() {
+         mNativeExtensionsMenuDelegateAndroid =
+                 ExtensionsMenuBridgeJni.get()
+-                        .init(this, task.getOrCreateNativeBrowserWindowPtr(profile));
++                        .init(this, mTask.getOrCreateNativeBrowserWindowPtr(mProfile));
+     }
+ 
+     @Override
+-    public void destroy() {
++    public void onFeatureRemoved() {
++        Instance().mObservers.remove(mTask);
++        destroy();
++    }
++
++    @Override
++    public void onTaskBoundsChanged(Rect newBoundsInDp) {}
++
++    @Override
++    public void onTaskFocusChanged(boolean hasFocus) {}
++
++    @Override
++    public void onTabModelSelected(ChromeAndroidTask task, TabModel tabModel) {
++        if (mTask == task && tabModel.getProfile() == mProfile) {
++            Instance().mNativeExtensionsMenuDelegateAndroid = mNativeExtensionsMenuDelegateAndroid;
++            Instance().mObserver = Instance().mObservers.get(mTask);
++        }
++    }
++
++    private void destroy() {
+         assert mNativeExtensionsMenuDelegateAndroid != 0;
+         ExtensionsMenuBridgeJni.get().destroy(mNativeExtensionsMenuDelegateAndroid);
+         mNativeExtensionsMenuDelegateAndroid = 0;
+@@ -41,12 +93,12 @@ public class ExtensionsMenuBridge implements Destroyable {
+ 
+     /** Returns a flattened list of action IDs and names from native. */
+     public String[] getActions() {
+-        return ExtensionsMenuBridgeJni.get().getActions(mNativeExtensionsMenuDelegateAndroid);
++        return ExtensionsMenuBridgeJni.get().getActions(Instance().mNativeExtensionsMenuDelegateAndroid);
+     }
+ 
+     /** Returns whether the native menu model is ready. */
+     public boolean isReady() {
+-        return ExtensionsMenuBridgeJni.get().isReady(mNativeExtensionsMenuDelegateAndroid);
++        return ExtensionsMenuBridgeJni.get().isReady(Instance().mNativeExtensionsMenuDelegateAndroid);
+     }
+ 
+     /**
+@@ -55,7 +107,7 @@ public class ExtensionsMenuBridge implements Destroyable {
+      */
+     @CalledByNative
+     public void onReady() {
+-        mObserver.onReady();
++        //Instance().mObserver.onReady();
+     }
+ 
+     public interface Observer {
+diff --git a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsToolbarBridge.java b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsToolbarBridge.java
+--- a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsToolbarBridge.java
++++ b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionsToolbarBridge.java
+@@ -21,10 +21,17 @@ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+ import org.chromium.chrome.browser.ui.toolbar.InvocationSource;
+ import org.chromium.content_public.browser.WebContents;
+ 
++import android.graphics.Rect;
++import android.util.ArrayMap;
++import java.util.Map;
++import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTaskFeature;
++import org.chromium.chrome.browser.tabmodel.TabModel;
++import org.chromium.base.Log;
++
+ /** A JNI bridge to interact with extension actions for the toolbar. */
+ @NullMarked
+ @JNINamespace("extensions")
+-public class ExtensionsToolbarBridge implements Destroyable {
++public class ExtensionsToolbarBridge implements ChromeAndroidTaskFeature {
+     private final @Nullable LifetimeAssert mLifetimeAssert = LifetimeAssert.create(this);
+     private long mNativeExtensionsToolbarAndroid;
+     private final ObserverList<Observer> mObservers = new ObserverList<>();
+@@ -33,14 +40,55 @@ public class ExtensionsToolbarBridge implements Destroyable {
+     // with {@code ExtensionActionListMediator}.
+     private @Nullable Delegate mDelegate;
+ 
+-    public ExtensionsToolbarBridge(ChromeAndroidTask task, Profile profile) {
++    private final ChromeAndroidTask mTask;
++    private final Profile mProfile;
++
++    private static ExtensionsToolbarBridge toolbarBridgeInstance;
++    private final Map<ChromeAndroidTask, Delegate> mDelegates = new ArrayMap<>();
++
++    @Override
++    public void onAddedToTask() {
+         mNativeExtensionsToolbarAndroid =
+                 ExtensionsToolbarBridgeJni.get()
+-                        .init(this, task.getOrCreateNativeBrowserWindowPtr(profile));
++                        .init(this, mTask.getOrCreateNativeBrowserWindowPtr(mProfile));
+     }
+ 
+     @Override
+-    public void destroy() {
++    public void onFeatureRemoved() {
++        Instance().mDelegates.remove(mTask);
++        destroy();
++    }
++
++    @Override
++    public void onTaskBoundsChanged(Rect newBoundsInDp) {}
++
++    @Override
++    public void onTaskFocusChanged(boolean hasFocus) {}
++
++    @Override
++    public void onTabModelSelected(ChromeAndroidTask task, TabModel tabModel) {
++        if (mTask == task && tabModel.getProfile() == mProfile) {
++            Instance().mNativeExtensionsToolbarAndroid = mNativeExtensionsToolbarAndroid;
++            Instance().mDelegate = Instance().mDelegates.get(mTask);
++        }
++    }
++
++    public static ExtensionsToolbarBridge Instance() {
++        if (toolbarBridgeInstance == null)
++            toolbarBridgeInstance = new ExtensionsToolbarBridge(null, null);
++        return toolbarBridgeInstance;
++    }
++
++    private ExtensionsToolbarBridge(ChromeAndroidTask task, Profile profile) {
++        mTask = task;
++        mProfile = profile;
++    }
++
++    public static ExtensionsToolbarBridge create(ChromeAndroidTask task, Profile profile) {
++        return new ExtensionsToolbarBridge(task, profile);
++    }
++
++    private void destroy() {
+         assert mNativeExtensionsToolbarAndroid != 0;
+         ExtensionsToolbarBridgeJni.get().destroy(mNativeExtensionsToolbarAndroid);
+         mNativeExtensionsToolbarAndroid = 0;
+@@ -48,21 +96,23 @@ public class ExtensionsToolbarBridge implements Destroyable {
+     }
+ 
+     public void addObserver(Observer observer) {
+-        mObservers.addObserver(observer);
++        Instance().mObservers.addObserver(observer);
+     }
+ 
+     public void removeObserver(Observer observer) {
+-        mObservers.removeObserver(observer);
++        Instance().mObservers.removeObserver(observer);
+     }
+ 
+-    public void setDelegate(@Nullable Delegate delegate) {
+-        mDelegate = delegate;
++    public void setDelegate(ChromeAndroidTask task, @Nullable Delegate delegate) {
++        Instance().mDelegates.put(task, delegate);
++        Instance().mDelegate = delegate;
+     }
+ 
+     @Nullable
+     public ExtensionAction getAction(String actionId) {
++        assert Instance().mNativeExtensionsToolbarAndroid != 0;
+         return ExtensionsToolbarBridgeJni.get()
+-                .getAction(mNativeExtensionsToolbarAndroid, actionId);
++                .getAction(Instance().mNativeExtensionsToolbarAndroid, actionId);
+     }
+ 
+     @Nullable
+@@ -72,9 +122,10 @@ public class ExtensionsToolbarBridge implements Destroyable {
+             int canvasWidthDp,
+             int canvasHeightDp,
+             float scaleFactor) {
++        assert Instance().mNativeExtensionsToolbarAndroid != 0;
+         return ExtensionsToolbarBridgeJni.get()
+                 .getIcon(
+-                        mNativeExtensionsToolbarAndroid,
++                        Instance().mNativeExtensionsToolbarAndroid,
+                         actionId,
+                         webContents,
+                         canvasWidthDp,
+@@ -83,28 +134,28 @@ public class ExtensionsToolbarBridge implements Destroyable {
+     }
+ 
+     public String[] getAllActionIds() {
+-        return ExtensionsToolbarBridgeJni.get().getAllActionIds(mNativeExtensionsToolbarAndroid);
++        return ExtensionsToolbarBridgeJni.get().getAllActionIds(Instance().mNativeExtensionsToolbarAndroid);
+     }
+ 
+     public String[] getPinnedActionIds() {
+-        return ExtensionsToolbarBridgeJni.get().getPinnedActionIds(mNativeExtensionsToolbarAndroid);
++        return ExtensionsToolbarBridgeJni.get().getPinnedActionIds(Instance().mNativeExtensionsToolbarAndroid);
+     }
+ 
+     public void executeUserAction(String actionId, @InvocationSource int source) {
+         ExtensionsToolbarBridgeJni.get()
+-                .executeUserAction(mNativeExtensionsToolbarAndroid, actionId, source);
++                .executeUserAction(Instance().mNativeExtensionsToolbarAndroid, actionId, source);
+     }
+ 
+     public void movePinnedAction(String actionId, int targetIndex) {
+         ExtensionsToolbarBridgeJni.get()
+-                .movePinnedAction(mNativeExtensionsToolbarAndroid, actionId, targetIndex);
++                .movePinnedAction(Instance().mNativeExtensionsToolbarAndroid, actionId, targetIndex);
+     }
+ 
+     public RequestAccessButtonParams getRequestAccessButtonParams(WebContents webContents) {
+-        assert mNativeExtensionsToolbarAndroid != 0;
++        assert Instance().mNativeExtensionsToolbarAndroid != 0;
+         RequestAccessButtonParams params =
+                 ExtensionsToolbarBridgeJni.get()
+-                        .getRequestAccessButtonParams(mNativeExtensionsToolbarAndroid, webContents);
++                        .getRequestAccessButtonParams(Instance().mNativeExtensionsToolbarAndroid, webContents);
+         assert params != null;
+         return params;
+     }
+@@ -112,56 +163,56 @@ public class ExtensionsToolbarBridge implements Destroyable {
+     @CalledByNative
+     public void triggerPopup(@JniType("std::string") String actionId, long nativeHostPtr) {
+         // {@link mDelegate} should be set in {@code ExtensionActionListMediator}'s constructor.
+-        assert mDelegate != null;
++        assert Instance().mDelegate != null;
+ 
+-        mDelegate.triggerPopup(actionId, nativeHostPtr);
++        Instance().mDelegate.triggerPopup(actionId, nativeHostPtr);
+     }
+ 
+     @CalledByNative
+     public void onRequestAccessButtonParamsChanged() {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onRequestAccessButtonParamsChanged();
+         }
+     }
+ 
+     @CalledByNative
+     public void onActionsInitialized() {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionsInitialized();
+         }
+     }
+ 
+     @CalledByNative
+     public void onActionAdded(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionAdded(actionId);
+         }
+     }
+ 
+     @CalledByNative
+     public void onActionRemoved(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionRemoved(actionId);
+         }
+     }
+ 
+     @CalledByNative
+     public void onActionUpdated(@JniType("std::string") String actionId) {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActionUpdated(actionId);
+         }
+     }
+ 
+     @CalledByNative
+     public void onPinnedActionsChanged() {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onPinnedActionsChanged();
+         }
+     }
+ 
+     @CalledByNative
+     public void onActiveWebContentsChanged() {
+-        for (Observer observer : mObservers) {
++        for (Observer observer : Instance().mObservers) {
+             observer.onActiveWebContentsChanged();
+         }
+     }
+diff --git a/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc b/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc
+--- a/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc
++++ b/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc
+@@ -130,6 +130,10 @@ void TabModelJniBridge::AssociateWithBrowserWindow(
+ // BrowserWindowInterface is available on desktop Android, but not other Android
+ // builds. For non-desktop Android, this function should be a no-op.
+ #if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
++  if (native_android_browser_window == 0) {
++    scoped_unowned_user_data_.reset();
++    return;
++  }
+   BrowserWindowInterface* android_browser_window =
+       reinterpret_cast<BrowserWindowInterface*>(native_android_browser_window);
+   CHECK(android_browser_window != nullptr);
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListCoordinator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListCoordinator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListCoordinator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListCoordinator.java
+@@ -30,6 +30,8 @@ import org.chromium.ui.listmenu.ListMenuButton;
+ import org.chromium.ui.modelutil.MVCListAdapter.ModelList;
+ import org.chromium.ui.modelutil.PropertyModel;
+ 
++import java.util.function.Function;
++
+ /**
+  * Root component for the extension action buttons. Exposes public API for external consumers to
+  * interact with the buttons and affect their states.
+@@ -38,14 +40,17 @@ import org.chromium.ui.modelutil.PropertyModel;
+ public class ExtensionActionListCoordinator implements Destroyable {
+     private final Context mContext;
+     private final ExtensionActionListRecyclerView mContainer;
++    private final ListMenuButton mExtensionsMenuButton;
+     private final ModelList mModels;
+     private final ExtensionActionListMediator mMediator;
+     private final DragReorderableRecyclerViewAdapter mAdapter;
+     @Nullable private final LifetimeAssert mLifetimeAssert = LifetimeAssert.create(this);
++    public final ExtensionsToolbarBridge mExtensionsToolbarBridge;
+ 
+     public ExtensionActionListCoordinator(
+             Context context,
+             ExtensionActionListRecyclerView container,
++            ListMenuButton extensionsMenuButton,
+             WindowAndroid windowAndroid,
+             ChromeAndroidTask task,
+             Profile profile,
+@@ -53,6 +58,8 @@ public class ExtensionActionListCoordinator implements Destroyable {
+             ExtensionsToolbarBridge extensionsToolbarBridge) {
+         mContext = context;
+         mContainer = container;
++        mExtensionsMenuButton = extensionsMenuButton;
++        mExtensionsToolbarBridge = extensionsToolbarBridge;
+ 
+         mModels = new ModelList();
+         mMediator =
+@@ -122,8 +129,13 @@ public class ExtensionActionListCoordinator implements Destroyable {
+         LifetimeAssert.setSafeToGc(mLifetimeAssert, true);
+     }
+ 
++    public void openPopup(String actionId) {
++        mMediator.onPrimaryClick(actionId);
++    }
++
+     /** Performs a click on the button for the given action. */
+     public void click(String actionId) {
++        mExtensionsMenuButton.dismiss();
+         for (int i = 0; i < mModels.size(); i++) {
+             if (mModels.get(i).model.get(ExtensionActionButtonProperties.ID).equals(actionId)) {
+                 RecyclerView.ViewHolder holder = mContainer.findViewHolderForAdapterPosition(i);
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListMediator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListMediator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListMediator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListMediator.java
+@@ -37,6 +37,7 @@ import org.chromium.ui.modelutil.PropertyModel;
+ import java.util.Arrays;
+ import java.util.HashSet;
+ import java.util.Set;
++import java.util.function.Function;
+ 
+ @NullMarked
+ class ExtensionActionListMediator implements Destroyable {
+@@ -44,7 +45,6 @@ class ExtensionActionListMediator implements Destroyable {
+     private final WindowAndroid mWindowAndroid;
+     private final ModelList mModels;
+     private final ChromeAndroidTask mTask;
+-    private final Profile mProfile;
+     private final NullableObservableSupplier<Tab> mCurrentTabSupplier;
+     private final ExtensionActionListRecyclerView mContainer;
+ 
+@@ -70,12 +70,11 @@ class ExtensionActionListMediator implements Destroyable {
+         mWindowAndroid = windowAndroid;
+         mModels = models;
+         mTask = task;
+-        mProfile = profile;
+         mCurrentTabSupplier = currentTabSupplier;
+         mContainer = container;
+         mExtensionsToolbarBridge = extensionsToolbarBridge;
+ 
+-        mExtensionsToolbarBridge.setDelegate(mToolbarDelegate);
++        mExtensionsToolbarBridge.setDelegate(mTask, mToolbarDelegate);
+         mExtensionsToolbarBridge.addObserver(mToolbarObserver);
+         reconcileActionItems();
+     }
+@@ -85,7 +84,7 @@ class ExtensionActionListMediator implements Destroyable {
+         closePopup();
+         assert mCurrentPopup == null;
+         mExtensionsToolbarBridge.removeObserver(mToolbarObserver);
+-        mExtensionsToolbarBridge.setDelegate(null);
++        mExtensionsToolbarBridge.setDelegate(mTask, null);
+         LifetimeAssert.setSafeToGc(mLifetimeAssert, true);
+     }
+ 
+@@ -234,7 +233,7 @@ class ExtensionActionListMediator implements Destroyable {
+         return mModels.get(index).model.get(ExtensionActionButtonProperties.ID);
+     }
+ 
+-    private void onPrimaryClick(String actionId) {
++    public void onPrimaryClick(String actionId) {
+         mExtensionsToolbarBridge.executeUserAction(actionId, InvocationSource.TOOLBAR_BUTTON);
+     }
+ 
+@@ -247,8 +246,7 @@ class ExtensionActionListMediator implements Destroyable {
+ 
+         View buttonView = getButtonViewForId(actionId);
+         if (buttonView == null) {
+-            contents.destroy();
+-            return;
++            buttonView = mContainer;
+         }
+ 
+         assert mCurrentPopup == null;
+@@ -291,7 +289,7 @@ class ExtensionActionListMediator implements Destroyable {
+ 
+         ExtensionActionContextMenuBridge bridge =
+                 new ExtensionActionContextMenuBridge(
+-                        mTask, mProfile, actionId, webContents, ContextMenuSource.TOOLBAR_ACTION);
++                        currentTab.getProfile(), mTask,  actionId, webContents, ContextMenuSource.TOOLBAR_ACTION);
+ 
+         ListMenuButton buttonView = (ListMenuButton) getButtonViewForId(actionId);
+         if (buttonView == null) {
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionsUpdateHelper.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionsUpdateHelper.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionsUpdateHelper.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionsUpdateHelper.java
+@@ -66,7 +66,7 @@ public class ExtensionActionsUpdateHelper implements Destroyable {
+         mModels = models;
+         mCurrentTabSupplier = currentTabSupplier;
+         mActionsUpdateDelegate = delegate;
+-        mExtensionActionsBridge = new ExtensionActionsBridge(task, profile);
++        mExtensionActionsBridge = ExtensionActionsBridge.Instance();
+ 
+         mCurrentTabSupplier.addObserver(mTabChangedCallback);
+         mExtensionActionsBridge.addObserver(mActionsObserver);
+@@ -135,7 +135,6 @@ public class ExtensionActionsUpdateHelper implements Destroyable {
+     public void destroy() {
+         mExtensionActionsBridge.removeObserver(mActionsObserver);
+         mCurrentTabSupplier.removeObserver(mTabChangedCallback);
+-        mExtensionActionsBridge.destroy();
+ 
+         mCurrentTab = null;
+     }
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinator.java
+@@ -16,12 +16,15 @@ import org.chromium.build.annotations.NullMarked;
+ import org.chromium.build.annotations.Nullable;
+ import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.tab.Tab;
++import org.chromium.chrome.browser.tabmodel.TabModel;
+ import org.chromium.chrome.browser.tabmodel.TabCreator;
+ import org.chromium.chrome.browser.theme.ThemeColorProvider;
+ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+ import org.chromium.chrome.browser.ui.extensions.ExtensionUi;
+ import org.chromium.ui.base.WindowAndroid;
+ 
++import java.util.function.Function;
++
+ /**
+  * The coordinator of the extension-related toolbar UI.
+  *
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java
+@@ -50,23 +50,18 @@ public class ExtensionToolbarCoordinatorImpl implements ExtensionToolbarCoordina
+             NullableObservableSupplier<Tab> currentTabSupplier,
+             TabCreator tabCreator,
+             ThemeColorProvider themeColorProvider) {
+-        mBridge = new ExtensionActionsBridge(task, profile);
++        mBridge = ExtensionActionsBridge.Instance();
+ 
+         extensionToolbarStub.setLayoutResource(R.layout.extension_toolbar_container);
+         LinearLayout container = (LinearLayout) extensionToolbarStub.inflate();
+ 
+-        mExtensionsToolbarBridge = new ExtensionsToolbarBridge(task, profile);
+-
+-        mProfileSupplier.addObserver((profile) -> {
+-            if (!ExtensionUi.isEnabled(profileSupplier.get())) {
+-                container.setVisibility(View.GONE);
+-            }
+-        });
++        mExtensionsToolbarBridge = ExtensionsToolbarBridge.Instance();
+ 
+         mExtensionActionListCoordinator =
+                 new ExtensionActionListCoordinator(
+                         context,
+                         container.findViewById(R.id.extension_action_list),
++                        container.findViewById(R.id.extensions_menu_button),
+                         windowAndroid,
+                         task,
+                         profile,
+@@ -90,8 +85,8 @@ public class ExtensionToolbarCoordinatorImpl implements ExtensionToolbarCoordina
+     public void destroy() {
+         mExtensionsMenuAndAccessControlButtonCoordinator.destroy();
+         mExtensionActionListCoordinator.destroy();
+-        mExtensionsToolbarBridge.destroy();
+-        mBridge.destroy();
++        //mExtensionsToolbarBridge.destroy();
++        //mBridge.destroy();
+         LifetimeAssert.setSafeToGc(mLifetimeAssert, true);
+     }
+ 
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuAndAccessControlButtonCoordinator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuAndAccessControlButtonCoordinator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuAndAccessControlButtonCoordinator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuAndAccessControlButtonCoordinator.java
+@@ -48,7 +48,8 @@ public class ExtensionsMenuAndAccessControlButtonCoordinator implements Destroya
+             NullableObservableSupplier<Tab> currentTabSupplier,
+             TabCreator tabCreator,
+             ExtensionsToolbarBridge extensionsToolbarBridge,
+-            View requestAccessButton) {
++            View requestAccessButton,
++            ExtensionActionListCoordinator extensionActionListCoordinator) {
+         mExtensionsMenuCoordinator =
+                 new ExtensionsMenuCoordinator(
+                         context,
+@@ -57,7 +58,7 @@ public class ExtensionsMenuAndAccessControlButtonCoordinator implements Destroya
+                         task,
+                         profile,
+                         currentTabSupplier,
+-                        tabCreator);
++                        tabCreator, extensionActionListCoordinator);
+ 
+         mExtensionAccessControlButtonCoordinator =
+                 new ExtensionAccessControlButtonCoordinator(
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java
+@@ -42,6 +42,8 @@ import org.chromium.ui.modelutil.PropertyModelChangeProcessor;
+ import org.chromium.ui.modelutil.SimpleRecyclerViewAdapter;
+ import org.chromium.ui.widget.RectProvider;
+ 
++import java.util.function.Function;
++
+ /**
+  * Coordinator for the extensions menu, accessed from the puzzle icon in the toolbar. This class is
+  * responsible for the button and the menu.
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java
+@@ -5,6 +5,7 @@
+ package org.chromium.chrome.browser.toolbar.extensions;
+ 
+ import android.content.Context;
++import android.graphics.Bitmap;
+ import android.graphics.Rect;
+ import android.view.View;
+ 
+@@ -13,6 +14,7 @@ import org.chromium.base.supplier.NullableObservableSupplier;
+ import org.chromium.build.annotations.NullMarked;
+ import org.chromium.chrome.browser.extensions.ContextMenuSource;
+ import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.tab.Tab;
+ import org.chromium.chrome.browser.toolbar.extensions.ExtensionActionListCoordinator;
+ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+@@ -25,6 +27,8 @@ import org.chromium.ui.modelutil.MVCListAdapter.ModelList;
+ import org.chromium.ui.modelutil.PropertyModel;
+ import org.chromium.ui.widget.RectProvider;
+ 
++import java.util.function.Function;
++
+ /**
+  * Mediator for the extensions menu. This class is responsible for listening to changes in the
+  * extensions and updating the model accordingly.
+@@ -38,7 +42,6 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+     private final PropertyModel mMenuPropertyModel;
+     private final Runnable mOnReady;
+     private final ChromeAndroidTask mTask;
+-    private final Profile mProfile;
+     private final View mRootView;
+     private final ExtensionActionListCoordinator mExtensionActionListCoordinator;
+ 
+@@ -68,9 +71,9 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+         mMenuPropertyModel = propertyModel;
+         mRootView = rootView;
+         mTask = task;
+-        mProfile = profile;
+ 
+-        mMenuBridge = new ExtensionsMenuBridge(mTask, mProfile, /* observer= */ this);
++        mMenuBridge = ExtensionsMenuBridge.Instance();
++        mMenuBridge.setObserver(task, /* observer= */ this);
+         if (mMenuBridge.isReady()) {
+             onReady();
+         }
+@@ -128,7 +131,7 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+ 
+         ExtensionActionContextMenuBridge contextMenuBridge =
+                 new ExtensionActionContextMenuBridge(
+-                        mTask, mProfile, actionId, webContents, ContextMenuSource.MENU_ITEM);
++                        currentTab.getProfile(), mTask, actionId, webContents, ContextMenuSource.MENU_ITEM);
+ 
+         ExtensionActionContextMenuUtils.showContextMenu(
+                 mContext,
+@@ -141,7 +144,7 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+     /** Destroys the mediator. */
+     @Override
+     public void destroy() {
+-        mMenuBridge.destroy();
++        //mMenuBridge.destroy();
+     }
+ 
+     /**
+@@ -159,12 +162,18 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+             final String id = actions[i];
+             final String name = actions[i + 1];
+ 
++            Bitmap icon =
++                    ExtensionActionIconUtil.getIcon(
++                            mContext, mExtensionActionListCoordinator.mExtensionsToolbarBridge,
++                            id, /*webContents*/ null);
++
+             PropertyModel model =
+                     new PropertyModel.Builder(ExtensionsMenuItemProperties.ALL_KEYS)
+                             .with(ExtensionsMenuItemProperties.TITLE, name)
++                            .with(ExtensionsMenuItemProperties.ICON, icon)
+                             .with(
+                                     ExtensionsMenuItemProperties.ITEM_CLICK_LISTENER,
+-                                    (view) -> mExtensionActionListCoordinator.click(actionId))
++                                    (view) -> mExtensionActionListCoordinator.openPopup(id))
+                             .with(
+                                     ExtensionsMenuItemProperties.CLICK_LISTENER,
+                                     (view) -> onContextMenuButtonClicked((ListMenuButton) view, id))
+diff --git a/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskImpl.java b/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskImpl.java
+--- a/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskImpl.java
++++ b/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskImpl.java
+@@ -250,7 +250,7 @@ final class ChromeAndroidTaskImpl
+                     // profile is destroyed. This should be fixed. For now we can just defer the
+                     // destruction until the activity is destroyed since there should never be more
+                     // than one profile/window on desktop Android.
+-                    if (!BuildConfig.IS_DESKTOP_ANDROID) {
++                    if (!BuildConfig.IS_DESKTOP_ANDROID_THORIUM) {
+                         var browserWindow = mAndroidBrowserWindows.remove(profile);
+                         if (browserWindow != null) {
+                             var ptr = browserWindow.getOrCreateNativePtr();
+@@ -284,6 +284,34 @@ final class ChromeAndroidTaskImpl
+ 
+                     associateTabModelWithBrowserWindow(incognitoModel);
+                 }
++
++                @Override
++                public void didDestroyed() {
++                    var activityScopedObjects = mActivityScopedObjectsDeque.peekFirst();
++                    assert activityScopedObjects != null
++                            : "ActivityScopedObjects should not be null if the"
++                                    + " mIncognitoTabModelObserver is registered.";
++                    var tabModelSelector = activityScopedObjects.mTabModelSelector;
++                    var incognitoModel = tabModelSelector.getModel(/* incognito= */ true);
++                    var incognitoProfile = incognitoModel.getProfile();
++                    var iterator = mFeatures.entrySet().iterator();
++                    while (iterator.hasNext()) {
++                        var entry = iterator.next();
++                        var key = entry.getKey();
++                        if (incognitoProfile.equals(key.mProfile)) {
++                            entry.getValue().onFeatureRemoved();
++                            iterator.remove();
++                        }
++                    }
++                    var browserWindow = mAndroidBrowserWindows.remove(incognitoProfile);
++                    if (browserWindow != null) {
++                        var ptr = browserWindow.getOrCreateNativePtr();
++                        for (var observer : mAndroidBrowserWindowObservers) {
++                            observer.onBrowserWindowRemoved(ptr);
++                        }
++                        browserWindow.destroy();
++                    }
++                }
+             };
+ 
+     private @Nullable Integer mId;
+@@ -548,7 +576,7 @@ final class ChromeAndroidTaskImpl
+             mFeatures.put(featureKey, feature);
+             feature.onAddedToTask();
+             if (tabModelSelector != null) {
+-                feature.onTabModelSelected(tabModelSelector.getCurrentModel());
++                feature.onTabModelSelected(this, tabModelSelector.getCurrentModel());
+             }
+         }
+     }
+@@ -964,6 +992,13 @@ final class ChromeAndroidTaskImpl
+         for (var feature : mFeatures.values()) {
+             feature.onTaskFocusChanged(isTopResumedActivity);
+         }
++        if (isTopResumedActivity) {
++            var topActivityScopedObjects = mActivityScopedObjectsDeque.peekFirst();
++            TabModelSelector tabModelSelector = topActivityScopedObjects.mTabModelSelector;
++            for (var feature : mFeatures.values()) {
++                feature.onTabModelSelected(this, tabModelSelector.getCurrentModel());
++            }
++        }
+     }
+ 
+     @Override
+@@ -1479,7 +1514,7 @@ final class ChromeAndroidTaskImpl
+ 
+     private void onTabModelSelected(TabModel tabModel) {
+         for (var feature : mFeatures.values()) {
+-            feature.onTabModelSelected(tabModel);
++            feature.onTabModelSelected(this, tabModel);
+         }
+     }
+ 
+diff --git a/chrome/browser/ui/browser_window/public/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskFeature.java b/chrome/browser/ui/browser_window/public/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskFeature.java
+--- a/chrome/browser/ui/browser_window/public/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskFeature.java
++++ b/chrome/browser/ui/browser_window/public/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskFeature.java
+@@ -55,5 +55,5 @@ public interface ChromeAndroidTaskFeature {
+      *
+      * @param tabModel The selected {@link TabModel}.
+      */
+-    default void onTabModelSelected(TabModel tabModel) {}
++    default void onTabModelSelected(ChromeAndroidTask task, TabModel tabModel) {}
+ }
+diff --git a/components/tabs/impl/tab_collection.cc b/components/tabs/impl/tab_collection.cc
+--- a/components/tabs/impl/tab_collection.cc
++++ b/components/tabs/impl/tab_collection.cc
+@@ -137,6 +137,22 @@ TabCollection::TabCollection(Type type,
+ 
+ TabCollection::~TabCollection() {
+   DispatchPendingNotifications();
++
++  auto& childrens = GetChildren();
++  for (auto it = childrens.begin(); it != childrens.end(); ) {
++    auto& child = *it;
++    if (std::holds_alternative<std::unique_ptr<TabInterface>>(child)) {
++      TabInterface* tab =
++          std::get<std::unique_ptr<TabInterface>>(child).get();
++      auto removed_tab = MaybeRemoveTab(tab);
++    } else if (std::holds_alternative<std::unique_ptr<TabCollection>>(child)) {
++      TabCollection* collection =
++          std::get<std::unique_ptr<TabCollection>>(child).get();
++      auto removed_collection = MaybeRemoveCollection(collection);
++    } else {
++      it++;
++    }
++  }
+ }
+ 
+ void TabCollection::AddObserver(TabCollectionObserver* observer) const {
+diff --git a/components/tabs/impl/tab_strip_collection.cc b/components/tabs/impl/tab_strip_collection.cc
+--- a/components/tabs/impl/tab_strip_collection.cc
++++ b/components/tabs/impl/tab_strip_collection.cc
+@@ -329,13 +329,13 @@ std::unique_ptr<TabInterface> TabStripCollection::RemoveTabAtIndexRecursive(
+ std::unique_ptr<TabInterface> TabStripCollection::MaybeRemoveTab(
+     TabInterface* tab) {
+   CHECK(tab);
+-  return nullptr;
++  return RemoveTabImpl(tab);
+ }
+ 
+ std::unique_ptr<TabCollection> TabStripCollection::MaybeRemoveCollection(
+     TabCollection* collection) {
+   CHECK(collection);
+-  return nullptr;
++  return TabStripCollection::RemoveTabCollection(collection);
+ }
+ 
+ void TabStripCollection::InsertTabCollectionAt(
+--

--- a/other/enable-extensions-android-thorium.patch
+++ b/other/enable-extensions-android-thorium.patch
@@ -1,0 +1,3855 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Thu, 6 Nov 2025 13:21:24 +0000
+Subject: Experimental support for extensions on Android
+
+Enable experimental support for extensions in Android.
+
+The feature is disabled by default: to enable it, go
+to Settings/Developer Options.
+A Clear all data used by the extension button is available in App
+info/Storage and cache/Clear storage to completely remove the extensions
+folder in case of a crash on startup.
+
+License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
+---
+ android_webview/BUILD.gn                      |  2 +-
+ base/allocator/partition_alloc_features.cc    |  2 +-
+ .../src/partition_alloc/BUILD.gn              |  3 +-
+ base/android/device_info.cc                   |  8 ++-
+ base/android/device_info.h                    |  3 +-
+ .../src/org/chromium/base/DeviceInfo.java     |  8 ++-
+ build/BUILD.gn                                |  2 +-
+ .../java/templates/BuildConfig.template       |  8 ++-
+ build/config/android/rules.gni                |  4 +-
+ build/config/chrome_build.gni                 |  7 +-
+ build/config/compiler/BUILD.gn                |  2 +-
+ build/config/compiler/pgo/BUILD.gn            |  2 +-
+ cc/resources/ui_resource_bitmap.cc            |  2 +-
+ chrome/android/BUILD.gn                       |  4 +-
+ chrome/android/chrome_public_apk_tmpl.gni     |  2 +-
+ .../java/res/layout/manage_space_activity.xml | 14 +++-
+ .../java/res/xml/developer_preferences.xml    |  6 ++
+ .../browser/ChromeBaseAppCompatActivity.java  |  2 +-
+ .../chrome/browser/app/ChromeActivity.java    |  2 +-
+ .../AppMenuPropertiesDelegateImpl.java        |  2 +-
+ .../settings/AppearanceSettingsFragment.java  |  2 +-
+ .../overlays/strip/StripLayoutUtils.java      |  2 +-
+ .../DesktopSiteSettingsIphController.java     |  2 +-
+ .../MediaCaptureNotificationServiceImpl.java  |  4 +-
+ .../browser/multiwindow/MultiWindowUtils.java |  2 +-
+ .../ChromeSiteSettingsDelegate.java           |  2 +-
+ .../site_settings/ManageSpaceActivity.java    | 20 ++++++
+ ...InterceptNavigationDelegateClientImpl.java |  2 +-
+ .../browser/tab/RequestDesktopUtils.java      |  2 +-
+ .../TabbedAppMenuPropertiesDelegate.java      |  2 +-
+ .../tabbed_mode/TabbedRootUiCoordinator.java  |  4 +-
+ chrome/app/extensions_strings.grdp            |  7 ++
+ chrome/app/theme/theme_resources.grd          |  4 +-
+ chrome/browser/BUILD.gn                       |  6 +-
+ chrome/browser/about_flags.cc                 |  4 ++
+ ...chrome_selection_dropdown_menu_delegate.cc |  4 +-
+ .../bookmarks/bar/BookmarkBarUtils.java       |  6 +-
+ .../bar/BookmarkBarVisibilityProvider.java    |  2 +-
+ .../BrowserControlsUtils.java                 |  2 +-
+ chrome/browser/browser_process_impl.cc        |  2 +-
+ chrome/browser/chrome_browser_field_trials.cc | 66 +++++++++----------
+ .../chrome_browser_interface_binders_webui.cc |  4 +-
+ .../browser/chrome_content_browser_client.cc  |  4 +-
+ chrome/browser/devtools/BUILD.gn              |  2 +-
+ .../chrome_download_manager_delegate.cc       |  2 +-
+ .../download_offline_content_provider.cc      |  4 +-
+ chrome/browser/extensions/BUILD.gn            | 12 +++-
+ .../chrome_extensions_api_client_android.cc   |  2 +-
+ .../extensions/api/identity/web_auth_flow.cc  |  6 +-
+ .../extensions/api/identity/web_auth_flow.h   |  4 +-
+ .../extensions/api/tabs/tabs_event_router.cc  |  3 +
+ .../extensions/extension_management.cc        |  8 ++-
+ .../browser/extensions/extension_management.h |  2 +-
+ chrome/browser/extensions/extension_util.cc   | 11 ++++
+ .../feedback/DeviceInfoFeedbackSource.java    |  2 +-
+ .../browser/flags/ChromeFeatureList.java      |  6 +-
+ chrome/browser/media/router/BUILD.gn          |  4 +-
+ .../browser/media/router/discovery/BUILD.gn   |  2 +-
+ .../media/router/media_router_feature.cc      | 10 +--
+ .../media/router/media_router_feature.h       |  2 +-
+ .../media/webrtc/webrtc_event_log_manager.cc  |  4 +-
+ .../browser/open_in_app/OpenInAppUtils.java   |  2 +-
+ .../policy_value_and_status_aggregator.cc     |  2 +-
+ ...hrome_browser_main_extra_parts_profiles.cc |  2 +-
+ .../profiles/off_the_record_profile_impl.cc   |  9 ++-
+ chrome/browser/profiles/profile_destroyer.cc  |  2 +-
+ chrome/browser/resources/BUILD.gn             |  2 +-
+ chrome/browser/resources/discards/BUILD.gn    |  2 +-
+ .../resources/extensions/detail_view.css      |  6 ++
+ .../resources/extensions/extensions.html      |  8 ++-
+ .../resources/extensions/item_list.css        | 10 +++
+ .../resources/extensions/toolbar.html.ts      |  7 --
+ .../sessions/session_restore_android.cc       |  4 +-
+ ...omeProvidedSharingOptionsProviderBase.java |  4 +-
+ chrome/browser/startup_data.cc                |  6 +-
+ chrome/browser/startup_data.h                 |  6 +-
+ .../common/task_manager_features.cc           |  2 +-
+ chrome/browser/ui/BUILD.gn                    |  4 +-
+ .../browser/ui/android/context_menu_helper.cc | 12 +++-
+ .../browser/ui/android/context_menu_helper.h  |  4 +-
+ .../desktop_site/DesktopSiteUtils.java        |  4 +-
+ .../TopControlsLockCoordinator.java           |  2 +-
+ chrome/browser/ui/android/extensions/BUILD.gn |  4 +-
+ .../extensions/extension_actions_bridge.cc    | 23 +++++++
+ .../extensions/extension_actions_bridge.h     |  1 +
+ .../extensions/extensions_toolbar_android.cc  |  1 +
+ .../java/res/layout/extensions_menu.xml       |  1 +
+ .../res/layout/extensions_menu_footer.xml     |  4 +-
+ .../extensions/java/res/values/dimens.xml     |  1 +
+ .../ui/extensions/ExtensionActionsBridge.java |  6 ++
+ .../extensions/windowing/internal/BUILD.gn    |  2 +-
+ .../extension_window_controller_bridge.cc     | 17 ++---
+ .../extension_window_controller_bridge.h      |  2 +-
+ .../Enable-extensions-Android.grdp            | 15 +++++
+ .../Extensions-Android.grdp                   |  9 +++
+ .../browser/ui/android/tab_model/tab_model.cc |  4 +-
+ .../browser/ui/android/tab_model/tab_model.h  |  2 +-
+ .../android/tab_model/tab_model_jni_bridge.cc | 12 ++--
+ .../android/tab_model/tab_model_test_helper.h |  2 +-
+ .../toolbar/java/res/layout/toolbar_phone.xml |  6 ++
+ .../ExtensionActionListRecyclerView.java      |  2 +-
+ .../ExtensionToolbarCoordinatorImpl.java      | 11 +++-
+ .../extensions/ExtensionsMenuCoordinator.java |  8 ++-
+ .../ExtensionsMenuItemProperties.java         |  5 +-
+ .../ExtensionsMenuItemViewBinder.java         |  2 +
+ .../extensions/ExtensionsMenuMediator.java    |  9 ++-
+ .../ChromeAndroidTaskTrackerFactory.java      |  4 --
+ chrome/browser/ui/prefs/BUILD.gn              |  4 +-
+ chrome/browser/ui/prefs/prefs_tab_helper.cc   |  8 +--
+ .../browser/ui/webui/chrome_web_ui_configs.cc |  4 +-
+ .../browser/ui/webui/current_channel_logo.cc  |  3 +-
+ .../browser/ui/webui/discards/discards_ui.cc  |  8 +--
+ chrome/chrome_paks.gni                        |  2 +-
+ chrome/common/chrome_switches.cc              |  2 +-
+ chrome/common/chrome_switches.h               |  2 +-
+ chrome/common/extensions/api/api_sources.gni  |  7 ++
+ chrome/common/webui_url_constants.cc          |  2 +-
+ chrome/common/webui_url_constants.h           |  2 +-
+ .../sandbox_status_extension_android.cc       |  3 +-
+ .../sandbox_status_extension_android.h        |  1 +
+ chrome/test/BUILD.gn                          | 18 ++---
+ chrome/version.gni                            |  4 +-
+ .../core/browser/host_content_settings_map.cc |  6 ++
+ .../embedder_support/view/ContentView.java    |  2 +-
+ .../embedder_support/user_agent_utils.cc      | 14 ++--
+ .../browser/android/media_router_android.cc   |  2 +-
+ .../browser/android/media_router_android.h    |  2 +-
+ .../media_router/browser/media_router.h       |  4 +-
+ .../policy/CombinedPolicyProvider.java        |  8 +--
+ .../components/policy/PolicyCacheUpdater.java |  2 +-
+ .../android/policy_cache_updater_android.cc   |  4 +-
+ .../cloud/user_policy_signin_service_base.cc  |  2 +-
+ .../configuration_policy_handler_list.cc      |  4 +-
+ .../common/cloud/cloud_policy_constants.cc    |  2 +-
+ components/policy/core/common/features.cc     |  2 +-
+ .../policy/core/common/policy_merger.cc       |  4 +-
+ .../installable/installable_icon_fetcher.cc   |  6 +-
+ .../installable/installable_icon_fetcher.h    |  2 +-
+ .../version/resources/about_version.html      |  2 +-
+ .../selection/selection_popup_controller.cc   |  5 ++
+ .../selection/selection_popup_controller.h    |  1 +
+ content/browser/browser_main_loop.cc          |  2 +-
+ .../media/video_capture_manager.cc            |  4 +-
+ .../media/video_capture_manager.h             |  6 +-
+ .../render_widget_host_view_android.cc        |  2 +-
+ .../browser/ContentUiEventHandler.java        |  7 +-
+ .../SelectionPopupControllerImpl.java         |  5 ++
+ content/public/common/content_features.cc     |  2 +-
+ .../render_frame_media_playback_options.cc    |  2 +-
+ .../about_flags_cc/Extensions-Android.inc     | 12 ++++
+ .../about_flags_cc/Webstore-protection.inc    |  8 +--
+ extensions/browser/BUILD.gn                   |  4 +-
+ ...browser_context_keyed_service_factories.cc |  2 +-
+ extensions/browser/api/system_cpu/BUILD.gn    |  2 +-
+ .../api/web_request/permission_helper.cc      |  2 +-
+ extensions/browser/extension_frame_host.cc    |  8 +++
+ extensions/browser/extension_host.cc          | 24 ++++++-
+ extensions/buildflags/BUILD.gn                |  3 +-
+ extensions/buildflags/buildflags.gni          |  4 +-
+ extensions/common/api/schema.gni              |  2 +-
+ extensions/common/command.cc                  |  2 +-
+ extensions/common/extension_features.cc       | 10 ++-
+ extensions/common/extension_features.h        |  6 +-
+ extensions/common/extension_l10n_util.cc      |  6 ++
+ extensions/common/features/feature.cc         |  2 +-
+ .../default_locale_handler.cc                 |  3 +
+ .../renderer/bindings/api_binding_util.cc     |  2 +-
+ gpu/config/gpu_finch_features.cc              |  4 +-
+ net/features.gni                              |  4 +-
+ skia/features.gni                             |  2 +-
+ third_party/blink/common/features.cc          |  2 +-
+ .../renderer/modules/modules_initializer.cc   |  4 +-
+ tools/grit/grit_args.gni                      |  3 +-
+ .../cpp_bundle_generator.py                   |  2 +-
+ .../ui/widget/PopupSpecCalculator.java        |  9 ++-
+ .../ui/test/util/UiDisableIfSkipCheck.java    |  8 +--
+ .../chromium/ui/test/util/UiRestriction.java  |  4 +-
+ ui/base/accelerators/command.cc               |  2 +-
+ ui/base/device_form_factor_android.cc         |  2 +-
+ ui/gl/features.gni                            |  2 +-
+ ui/resources/ui_resources.grd                 |  2 +-
+ ui/webui/resources/BUILD.gn                   |  4 +-
+ ui/webui/resources/cr_elements/BUILD.gn       |  2 +-
+ .../cr_elements/cr_toolbar/cr_toolbar.css     |  3 +
+ ui/webui/resources/css/BUILD.gn               |  2 +-
+ 185 files changed, 605 insertions(+), 311 deletions(-)
+ create mode 100644 chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Enable-extensions-Android.grdp
+ create mode 100644 chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Extensions-Android.grdp
+ create mode 100644 thorium_flags/chrome/browser/about_flags_cc/Extensions-Android.inc
+
+diff --git a/android_webview/BUILD.gn b/android_webview/BUILD.gn
+--- a/android_webview/BUILD.gn
++++ b/android_webview/BUILD.gn
+@@ -1308,7 +1308,7 @@ declare_args() {
+       # logic more easily on an emulator, so the decision to use the arm64
+       # orderfile for x64 (instead of arm32) is somewhat arbitrary. We just
+       # needed to use some real orderfile.
+-      if (is_desktop_android && current_cpu == "x64") {
++      if (is_desktop_android_false_thorium && current_cpu == "x64") {
+         # For Android Desktop x64, orderfile is disabled, see
+         # https://crbug.com/422005929.
+         webview_orderfile_path = ""
+diff --git a/base/allocator/partition_alloc_features.cc b/base/allocator/partition_alloc_features.cc
+--- a/base/allocator/partition_alloc_features.cc
++++ b/base/allocator/partition_alloc_features.cc
+@@ -190,7 +190,7 @@ BASE_FEATURE_ENUM_PARAM(BackupRefPtrEnabledProcesses,
+                         kBackupRefPtrEnabledProcessesParam,
+                         &kPartitionAllocBackupRefPtr,
+                         kPAFeatureEnabledProcessesStr,
+-#if PA_BUILDFLAG(IS_ANDROID) && !PA_BUILDFLAG(IS_DESKTOP_ANDROID)
++#if PA_BUILDFLAG(IS_ANDROID) && !PA_BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+                         BackupRefPtrEnabledProcesses::kNonRenderer,
+ #else
+                         BackupRefPtrEnabledProcesses::kAllProcesses,
+diff --git a/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn b/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
+--- a/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
++++ b/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
+@@ -165,7 +165,8 @@ pa_buildflag_header("buildflags") {
+     "HAS_64_BIT_POINTERS=$has_64_bit_pointers",
+     "HAS_MEMORY_TAGGING=$has_memory_tagging",
+     "IS_ANDROID=$is_android",
+-    "IS_DESKTOP_ANDROID=$is_desktop_android",
++    "IS_DESKTOP_ANDROID_FALSE=false",
++    "IS_DESKTOP_ANDROID_THORIUM=$is_desktop_android_thorium",
+     "IS_CASTOS=$is_castos",
+     "IS_CAST_ANDROID=$is_cast_android",
+     "IS_CHROMEOS=$is_chromeos",
+diff --git a/base/android/device_info.cc b/base/android/device_info.cc
+--- a/base/android/device_info.cc
++++ b/base/android/device_info.cc
+@@ -103,10 +103,14 @@ bool is_foldable() {
+   return get_device_info().isFoldable;
+ }
+ 
+-bool is_desktop() {
++bool is_desktop_cromite() {
+   return get_device_info().isDesktop;
+ }
+ 
++bool is_desktop_false() {
++  return false;
++}
++
+ // Available only on Android T+.
+ int32_t vulkan_deqp_level() {
+   return get_device_info().vulkanDeqpLevel;
+@@ -122,7 +126,7 @@ bool is_xr() {
+ // check) as a first choice, but fall back to this if not feasible.
+ bool is_tablet() {
+   return was_launched_on_large_display() && !is_tv() && !is_automotive() &&
+-         !is_desktop() && !is_xr();
++         !is_desktop_false() && !is_xr();
+ }
+ 
+ // This returns the cached value during initial startup. If you need this
+diff --git a/base/android/device_info.h b/base/android/device_info.h
+--- a/base/android/device_info.h
++++ b/base/android/device_info.h
+@@ -29,7 +29,8 @@ BASE_EXPORT void Set(const IDeviceInfo& info);
+ BASE_EXPORT bool is_tv();
+ BASE_EXPORT bool is_automotive();
+ BASE_EXPORT bool is_foldable();
+-BASE_EXPORT bool is_desktop();
++BASE_EXPORT bool is_desktop_cromite();
++BASE_EXPORT bool is_desktop_false();
+ // Available only on Android T+.
+ BASE_EXPORT int32_t vulkan_deqp_level();
+ BASE_EXPORT bool is_xr();
+diff --git a/base/android/java/src/org/chromium/base/DeviceInfo.java b/base/android/java/src/org/chromium/base/DeviceInfo.java
+--- a/base/android/java/src/org/chromium/base/DeviceInfo.java
++++ b/base/android/java/src/org/chromium/base/DeviceInfo.java
+@@ -128,10 +128,14 @@ public final class DeviceInfo {
+         return getInstance().mIDeviceInfo.isFoldable;
+     }
+ 
+-    public static boolean isDesktop() {
++    public static boolean isDesktopCromite() {
+         return getInstance().mIDeviceInfo.isDesktop;
+     }
+ 
++    public static boolean isDesktopFalse() {
++        return false;
++    }
++
+     public static int getVulkanDeqpLevel() {
+         return getInstance().mIDeviceInfo.vulkanDeqpLevel;
+     }
+@@ -283,7 +287,7 @@ public final class DeviceInfo {
+         }
+ 
+         mIDeviceInfo.isDesktop =
+-                (BuildConfig.IS_DESKTOP_ANDROID && pm.hasSystemFeature(PackageManager.FEATURE_PC))
++                (BuildConfig.IS_DESKTOP_ANDROID_FALSE && pm.hasSystemFeature(PackageManager.FEATURE_PC))
+                         || CommandLine.getInstance().hasSwitch(BaseSwitches.FORCE_DESKTOP_ANDROID);
+ 
+         // Detect whether device is foldable.
+diff --git a/build/BUILD.gn b/build/BUILD.gn
+--- a/build/BUILD.gn
++++ b/build/BUILD.gn
+@@ -128,7 +128,7 @@ buildflag_header("ios_buildflags") {
+ #
+ buildflag_header("android_buildflags") {
+   header = "android_buildflags.h"
+-  flags = [ "IS_DESKTOP_ANDROID=$is_desktop_android" ]
++  flags = [ "IS_DESKTOP_ANDROID_THORIUM=$is_desktop_android_thorium", "IS_DESKTOP_ANDROID_FALSE=false" ]
+ }
+ 
+ if (build_with_chromium) {
+diff --git a/build/android/java/templates/BuildConfig.template b/build/android/java/templates/BuildConfig.template
+--- a/build/android/java/templates/BuildConfig.template
++++ b/build/android/java/templates/BuildConfig.template
+@@ -110,10 +110,12 @@ public class BuildConfig {
+     // DeviceInfo.java since this is the source of truth for isDesktop check.
+     // (TODO: crbug.com/430983585) Clean up this flag once the desktop
+     // build is fully functional.
+-#if defined(_IS_DESKTOP_ANDROID)
+-    public static boolean IS_DESKTOP_ANDROID = true;
++#if defined(_IS_DESKTOP_ANDROID_THORIUM)
++    public static boolean IS_DESKTOP_ANDROID_THORIUM = true;
++    public static boolean IS_DESKTOP_ANDROID_FALSE;
+ #else
+-    public static boolean IS_DESKTOP_ANDROID;
++    public static boolean IS_DESKTOP_ANDROID_THORIUM;
++    public static boolean IS_DESKTOP_ANDROID_FALSE;
+ #endif
+ 
+     // Use to check if proguard is enabled for the current build.
+diff --git a/build/config/android/rules.gni b/build/config/android/rules.gni
+--- a/build/config/android/rules.gni
++++ b/build/config/android/rules.gni
+@@ -2031,8 +2031,8 @@ if (!is_robolectric && enable_java_templates) {
+       } else {
+         defines += [ "_LOGTAG_PREFIX=cr_" ]
+       }
+-      if (is_desktop_android) {
+-        defines += [ "_IS_DESKTOP_ANDROID" ]
++      if (is_desktop_android_thorium) {
++        defines += [ "_IS_DESKTOP_ANDROID_THORIUM" ]
+       }
+ 
+       if (enable_javaless_renderers) {
+diff --git a/build/config/chrome_build.gni b/build/config/chrome_build.gni
+--- a/build/config/chrome_build.gni
++++ b/build/config/chrome_build.gni
+@@ -34,7 +34,8 @@ declare_args() {
+ 
+   # Set to true to set defaults that enable features on Android that are more
+   # typically available on desktop.
+-  is_desktop_android = false
++  is_desktop_android_thorium = is_android
++  is_desktop_android_false_thorium = false
+ 
+   if (is_android) {
+     # By default, Trichrome channels are compiled using separate package names.
+@@ -56,12 +57,12 @@ is_internal_chrome_branded = enable_src_internal && is_chrome_branded
+ # Ensure !is_android implies !is_high_end_android.
+ is_high_end_android = is_high_end_android && is_android
+ 
+-if (is_desktop_android) {
++if (is_desktop_android_thorium) {
+   assert(target_os == "android",
+          "Target must be Android to use is_desktop_android.")
+ 
+   # Disable for non-android secondary toolchains.
+-  is_desktop_android = is_android
++  is_desktop_android_thorium = is_android
+ }
+ 
+ declare_args() {
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -242,7 +242,7 @@ if (is_android) {
+         # logic more easily on an emulator, so the decision to use the arm64
+         # orderfile for x64 (instead of arm32) is somewhat arbitrary. We just
+         # needed to use some real orderfile.
+-        if (is_desktop_android && current_cpu == "x64") {
++        if (is_desktop_android_false_thorium && current_cpu == "x64") {
+           # For Android Desktop x64, orderfile is disabled, see
+           # https://crbug.com/422005929.
+           chrome_orderfile_path = ""
+diff --git a/build/config/compiler/pgo/BUILD.gn b/build/config/compiler/pgo/BUILD.gn
+--- a/build/config/compiler/pgo/BUILD.gn
++++ b/build/config/compiler/pgo/BUILD.gn
+@@ -78,7 +78,7 @@ config("pgo_optimization_flags") {
+       _pgo_target = "linux"
+     } else if (is_android) {
+       # Use |current_cpu| and not |target_cpu|; for Android we may built both.
+-      if (is_desktop_android && current_cpu == "x64") {
++      if (is_desktop_android_false_thorium && current_cpu == "x64") {
+         _pgo_target = "android-desktop-x64"
+       } else if (current_cpu == "arm64") {
+         _pgo_target = "android-arm64"
+diff --git a/cc/resources/ui_resource_bitmap.cc b/cc/resources/ui_resource_bitmap.cc
+--- a/cc/resources/ui_resource_bitmap.cc
++++ b/cc/resources/ui_resource_bitmap.cc
+@@ -101,7 +101,7 @@ UIResourceBitmap::UIResourceBitmap(const SkBitmap& skbitmap) {
+ #if BUILDFLAG(IS_ANDROID)
+   SkBitmap copy;
+   if (features::ShouldEnableDrDc() ||
+-      base::android::device_info::is_desktop()) {
++      base::android::device_info::is_desktop_false()) {
+     // On android desktop, where JavaBitmap ensures 4 byte alignment, uploading
+     // ALPHA_8 to angle_vulkan_image_backing may fail because it expects 1 byte
+     // alignment stride. Workaround via copying it to N32.
+diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
+--- a/chrome/android/BUILD.gn
++++ b/chrome/android/BUILD.gn
+@@ -970,7 +970,7 @@ if (_is_default_toolchain) {
+       "//chrome/browser/password_entry_edit/android/internal:java",
+     ]
+ 
+-    if (is_desktop_android) {
++    if (is_desktop_android_thorium) {
+       deps +=
+           [ "//chrome/browser/ui/android/extensions/windowing/internal:java" ]
+     } else {
+@@ -2341,7 +2341,7 @@ if (_is_default_toolchain) {
+       "//components/embedder_support/android:virtual_structure_javatests",
+     ]
+ 
+-    if (is_desktop_android) {
++    if (is_desktop_android_thorium) {
+       deps += [
+         "//chrome/browser/ui/android/extensions/windowing/internal:javatests",
+ 
+diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_public_apk_tmpl.gni
+--- a/chrome/android/chrome_public_apk_tmpl.gni
++++ b/chrome/android/chrome_public_apk_tmpl.gni
+@@ -39,7 +39,7 @@ default_chrome_public_jinja_variables = [
+   "enable_vr=$enable_vr",
+   "enable_openxr=$enable_openxr",
+   "enable_arcore=$enable_arcore",
+-  "is_desktop_android=$is_desktop_android",
++  "is_desktop_android_thorium=$is_desktop_android_thorium",
+   "enable_screen_capture=$enable_screen_capture",
+   "zygote_preload_class=org.chromium.content_public.app.ZygotePreload",
+ ]
+diff --git a/chrome/android/java/res/layout/manage_space_activity.xml b/chrome/android/java/res/layout/manage_space_activity.xml
+--- a/chrome/android/java/res/layout/manage_space_activity.xml
++++ b/chrome/android/java/res/layout/manage_space_activity.xml
+@@ -94,5 +94,17 @@ found in the LICENSE file.
+             android:id="@+id/clear_all_data"
+             android:text="@string/storage_management_clear_all_data_button"
+                 style="@style/ManageSpaceActivityButton" />
++
++        <!-- ======== Extension storage info ======== -->
++        <TextView
++            android:id="@+id/all_extension_description"
++            android:text="@string/storage_management_extension_storage_description"
++            android:paddingTop="12dp"
++            style="@style/ManageSpaceActivityExplanationTextView" />
++
++        <Button
++            android:id="@+id/clear_extension_data"
++            android:text="@string/storage_management_clear_all_extension_button"
++                style="@style/ManageSpaceActivityButton" />
+     </LinearLayout>
+-</ScrollView>
+\ No newline at end of file
++</ScrollView>
+diff --git a/chrome/android/java/res/xml/developer_preferences.xml b/chrome/android/java/res/xml/developer_preferences.xml
+--- a/chrome/android/java/res/xml/developer_preferences.xml
++++ b/chrome/android/java/res/xml/developer_preferences.xml
+@@ -44,4 +44,10 @@ found in the LICENSE file.
+         android:key="pixel_perfect_mode"
+         android:title="@string/android_pixel_perfect_mode_title"
+         android:summary="@string/android_pixel_perfect_mode_summary" />
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="enable_extensions_android"
++        android:title="@string/android_extensions_title"
++        android:summary="@string/android_extensions_summary"
++        app:featureName="enable-extensions-android"
++        app:needRestart="true" />
+ </PreferenceScreen>
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeBaseAppCompatActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeBaseAppCompatActivity.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeBaseAppCompatActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeBaseAppCompatActivity.java
+@@ -619,7 +619,7 @@ public class ChromeBaseAppCompatActivity extends AppCompatActivity
+             applySingleThemeOverlay(R.style.ThemeOverlay_BrowserUI_OptOutEdgeToEdge);
+         }
+ 
+-        if (ChromeFeatureList.sAndroidDesktopDensity.isEnabled() && DeviceInfo.isDesktop()) {
++        if (ChromeFeatureList.sAndroidDesktopDensity.isEnabled() && DeviceInfo.isDesktopFalse()) {
+             applySingleThemeOverlay(R.style.ThemeOverlay_BrowserUI_DesktopDensity);
+         }
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+@@ -2107,7 +2107,7 @@ public abstract class ChromeActivity extends AsyncInitializationActivity
+                 HostZoomMap.setTransparentZoomAdjustment(
+                         (float) ContentFeatureList.sAndroidMonitorZoomScalingFactor.getValue()
+                                 / 100.0f);
+-            } else if (DeviceInfo.isDesktop()) {
++            } else if (DeviceInfo.isDesktopFalse()) {
+                 HostZoomMap.setTransparentZoomAdjustment(
+                         (float) ContentFeatureList.sAndroidDesktopZoomScalingFactor.getValue()
+                                 / 100.0f);
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/app/appmenu/AppMenuPropertiesDelegateImpl.java
+@@ -1191,7 +1191,7 @@ public abstract class AppMenuPropertiesDelegateImpl implements AppMenuProperties
+                         && !shouldShowReaderModePrefs(currentTab)
+                         && currentTab != null
+                         && currentTab.getWebContents() != null
+-                        && !DeviceInfo.isDesktop();
++                        && !DeviceInfo.isDesktopFalse();
+ 
+         if (!itemVisible) return null;
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/appearance/settings/AppearanceSettingsFragment.java b/chrome/android/java/src/org/chromium/chrome/browser/appearance/settings/AppearanceSettingsFragment.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/appearance/settings/AppearanceSettingsFragment.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/appearance/settings/AppearanceSettingsFragment.java
+@@ -64,7 +64,7 @@ public class AppearanceSettingsFragment extends ChromeBaseSettingsFragment
+ 
+         // This fragment may be used on Desktop or tablets. For Desktop we use the current Profile's
+         // UserPrefs. For tablets, we use the local device preference.
+-        mUseProfileUserPrefs = DeviceInfo.isDesktop();
++        mUseProfileUserPrefs = DeviceInfo.isDesktopFalse();
+         initBookmarkBarPref();
+         initToolbarShortcutPref();
+         initUiThemePref();
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutUtils.java b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutUtils.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutUtils.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/compositor/overlays/strip/StripLayoutUtils.java
+@@ -415,7 +415,7 @@ public class StripLayoutUtils {
+ 
+     public static boolean shouldApplyMoreDensity() {
+         return ChromeFeatureList.sTabStripDensityChangeAndroid.isEnabled()
+-                && DeviceInfo.isDesktop();
++                && DeviceInfo.isDesktopFalse();
+     }
+ 
+     // Testing booleans
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteSettingsIphController.java b/chrome/android/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteSettingsIphController.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteSettingsIphController.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteSettingsIphController.java
+@@ -80,7 +80,7 @@ public class DesktopSiteSettingsIphController {
+             View toolbarMenuButton,
+             AppMenuHandler appMenuHandler) {
+         // Desktop site settings are default enabled on desktop. Do not show IPH.
+-        if(DeviceInfo.isDesktop()) return null;
++        if(DeviceInfo.isDesktopFalse()) return null;
+         return new DesktopSiteSettingsIphController(
+                 windowAndroid,
+                 activityTabProvider,
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/media/MediaCaptureNotificationServiceImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/media/MediaCaptureNotificationServiceImpl.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/media/MediaCaptureNotificationServiceImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/media/MediaCaptureNotificationServiceImpl.java
+@@ -219,7 +219,7 @@ public class MediaCaptureNotificationServiceImpl extends SplitCompatService.Impl
+                 }
+             }
+             mNotificationsType.remove(notificationId);
+-            if (DeviceInfo.isDesktop()) {
++            if (DeviceInfo.isDesktopFalse()) {
+                 int lastIndex = mNotifications.size() - 1;
+                 boolean isRemovingLatestNotification =
+                         lastIndex >= 0 && mNotifications.get(lastIndex).first == notificationId;
+@@ -315,7 +315,7 @@ public class MediaCaptureNotificationServiceImpl extends SplitCompatService.Impl
+                         contentIntent,
+                         stopIntent);
+         mNotificationsType.put(notificationId, mediaTypes);
+-        if (DeviceInfo.isDesktop()) {
++        if (DeviceInfo.isDesktopFalse()) {
+             // For large screen device, we use the latest notification to start or update
+             // the foreground service.
+             startOrUpdateForegroundService(notificationId, notification);
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiWindowUtils.java b/chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiWindowUtils.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiWindowUtils.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiWindowUtils.java
+@@ -201,7 +201,7 @@ public class MultiWindowUtils implements ActivityStateListener {
+             return TabWindowManager.MAX_SELECTORS_S;
+         }
+ 
+-        if (DeviceInfo.isDesktop()) {
++        if (DeviceInfo.isDesktopFalse()) {
+             return TabWindowManager.MAX_SELECTORS;
+         }
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ChromeSiteSettingsDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ChromeSiteSettingsDelegate.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ChromeSiteSettingsDelegate.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ChromeSiteSettingsDelegate.java
+@@ -175,7 +175,7 @@ public class ChromeSiteSettingsDelegate implements SiteSettingsDelegate {
+                 return PermissionUtil.handTrackingNeedsAdditionalPermissions();
+             case SiteSettingsCategory.Type.REQUEST_DESKTOP_SITE:
+                 // Desktop Android always requests desktop sites, so hide the category.
+-                return !DeviceInfo.isDesktop();
++                return !DeviceInfo.isDesktopFalse();
+             case SiteSettingsCategory.Type.LOCAL_NETWORK_ACCESS:
+                 // Use LOCAL_NETWORK_ACCESS if LNA is enabled, but LNA Split permissions is not
+                 // enabled.
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ManageSpaceActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ManageSpaceActivity.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ManageSpaceActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/site_settings/ManageSpaceActivity.java
+@@ -41,6 +41,7 @@ import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
+ import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.profiles.ProfileManager;
+ import org.chromium.chrome.browser.settings.SettingsNavigationFactory;
++import org.chromium.chrome.browser.ui.extensions.ExtensionActionsBridge;
+ import org.chromium.chrome.browser.ui.searchactivityutils.SearchActivityPreferencesManager;
+ import org.chromium.components.browser_ui.settings.SettingsNavigation;
+ import org.chromium.components.browser_ui.site_settings.AllSiteSettings;
+@@ -68,6 +69,7 @@ public class ManageSpaceActivity extends ChromeBaseAppCompatActivity
+     private Button mClearUnimportantButton;
+     private Button mManageSiteDataButton;
+     private Button mClearAllDataButton;
++    private Button mClearExtensionDataButton;
+     // Stored for testing.
+     private @Nullable AlertDialog mUnimportantDialog;
+ 
+@@ -106,6 +108,9 @@ public class ManageSpaceActivity extends ChromeBaseAppCompatActivity
+ 
+         mClearAllDataButton = findViewById(R.id.clear_all_data);
+         mClearAllDataButton.setOnClickListener(this);
++
++        mClearExtensionDataButton = findViewById(R.id.clear_extension_data);
++        mClearExtensionDataButton.setOnClickListener(this);
+         super.onCreate(savedInstanceState);
+ 
+         BrowserParts parts =
+@@ -267,6 +272,21 @@ public class ManageSpaceActivity extends ChromeBaseAppCompatActivity
+             builder.setTitle(R.string.storage_management_reset_app_dialog_title);
+             builder.setMessage(R.string.storage_management_reset_app_dialog_text);
+             builder.create().show();
++        } else if (view == mClearExtensionDataButton) {
++            AlertDialog.Builder builder = new AlertDialog.Builder(this);
++            builder.setPositiveButton(
++                    R.string.ok,
++                    new DialogInterface.OnClickListener() {
++                        @Override
++                        public void onClick(DialogInterface dialog, int id) {
++                            Profile profile = ProfileManager.getLastUsedRegularProfile();
++                            // ExtensionActionsBridge.get(profile).clearExtensionData();
++                        }
++                    });
++            builder.setNegativeButton(R.string.cancel, null);
++            builder.setTitle(R.string.storage_management_extension_reset_app_dialog_title);
++            builder.setMessage(R.string.storage_management_extension_reset_app_dialog_text);
++            builder.create().show();
+         }
+     }
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/InterceptNavigationDelegateClientImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/InterceptNavigationDelegateClientImpl.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tab/InterceptNavigationDelegateClientImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/InterceptNavigationDelegateClientImpl.java
+@@ -208,7 +208,7 @@ public class InterceptNavigationDelegateClientImpl implements InterceptNavigatio
+         // TODO(crbug.com/417047079): Replace the following desktop windowing checks with a better
+         // approach.
+         // return MultiWindowUtils.getInstance().isInMultiWindowMode(getActivity());
+-        return DeviceInfo.isDesktop();
++        return DeviceInfo.isDesktopFalse();
+     }
+ 
+     @Override
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/RequestDesktopUtils.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/RequestDesktopUtils.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tab/RequestDesktopUtils.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/RequestDesktopUtils.java
+@@ -107,7 +107,7 @@ public class RequestDesktopUtils {
+ 
+         // Desktop devices always request desktop sites so there's no need to show a message to
+         // the user.
+-        if (DeviceInfo.isDesktop()) {
++        if (DeviceInfo.isDesktopFalse()) {
+             return false;
+         }
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedAppMenuPropertiesDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedAppMenuPropertiesDelegate.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedAppMenuPropertiesDelegate.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedAppMenuPropertiesDelegate.java
+@@ -863,7 +863,7 @@ public class TabbedAppMenuPropertiesDelegate extends AppMenuPropertiesDelegateIm
+             return false;
+         }
+ 
+-        return DeviceInfo.isDesktop() || isPdf;
++        return DeviceInfo.isDesktopFalse() || isPdf;
+     }
+ 
+     private MVCListAdapter.ListItem buildPrintItem(Tab currentTab) {
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/TabbedRootUiCoordinator.java
+@@ -647,7 +647,7 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
+                 });
+ 
+         mCrossDeviceSettingImporter =
+-                DeviceInfo.isDesktop()
++                ((true))
+                         ? null
+                         : new CrossDeviceSettingImporter(
+                                 activityLifecycleDispatcher,
+@@ -2133,7 +2133,7 @@ public class TabbedRootUiCoordinator extends RootUiCoordinator {
+         } else if (id == R.id.toggle_bookmark_bar) {
+             // isActivityStateBookmarkBarCompatible already checks the flag sAndroidBookmarkBar.
+             if (BookmarkBarUtils.isActivityStateBookmarkBarCompatible(mActivity)) {
+-                if (DeviceInfo.isDesktop()) {
++                if (DeviceInfo.isDesktopCromite()) {
+                     // Desktop uses the synced UserPref.
+                     BookmarkBarUtils.toggleUserPrefsShowBookmarksBar(
+                             mProfileSupplier.get(), /* fromKeyboardShortcut= */ true);
+diff --git a/chrome/app/extensions_strings.grdp b/chrome/app/extensions_strings.grdp
+--- a/chrome/app/extensions_strings.grdp
++++ b/chrome/app/extensions_strings.grdp
+@@ -400,9 +400,16 @@
+   <message name="IDS_EXTENSIONS_NO_ACTIVITIES" desc="The message shown to the user when an extension has no recent activities.">
+     No recent activities
+   </message>
++<if expr="is_android">
++  <message name="IDS_EXTENSIONS_NO_INSTALLED_ITEMS" desc="The message shown to the user on the Extensions settings page when there are no extensions or apps installed.">
++    Find extensions and themes in the <ph name="BEGIN_LINK">&lt;a target="_blank" href="https://chromewebstore.google.com"&gt;</ph>Chromedontreplace Web Store<ph name="END_LINK">&lt;/a&gt;<ex>&lt;/a&gt;</ex></ph>
++  </message>
++</if>
++<if expr="not is_android">
+   <message name="IDS_EXTENSIONS_NO_INSTALLED_ITEMS" desc="The message shown to the user on the Extensions settings page when there are no extensions or apps installed.">
+     Find extensions and themes in the <ph name="BEGIN_LINK">&lt;a target="_blank" href="https://chrome.google.com/webstore/category/extensions"&gt;</ph>Chromedontreplace Web Store<ph name="END_LINK">&lt;/a&gt;<ex>&lt;/a&gt;</ex></ph>
+   </message>
++</if>
+   <message name="IDS_EXTENSIONS_NO_DESCRIPTION" desc="The message shown to the user when an extension does not have any description.">
+     No description provided
+   </message>
+diff --git a/chrome/app/theme/theme_resources.grd b/chrome/app/theme/theme_resources.grd
+--- a/chrome/app/theme/theme_resources.grd
++++ b/chrome/app/theme/theme_resources.grd
+@@ -379,7 +379,7 @@
+         <structure type="chrome_scaled_image" name="IDR_UPLOAD_VIOLATION_DARK" file="common/upload_violation_dark.png" />
+       </if>
+       <if expr="not _google_chrome">
+-        <if expr="not is_android or is_desktop_android">
++        <if expr="not is_android or is_desktop_android_thorium">
+           <!-- Desktop Android supports extensions and the web store. -->
+           <structure type="chrome_scaled_image" name="IDR_WEBSTORE_ICON" file="chromium/webstore_icon.png" />
+           <structure type="chrome_scaled_image" name="IDR_WEBSTORE_ICON_16" file="chromium/webstore_icon_16.png" />
+@@ -388,7 +388,7 @@
+         </if>
+       </if>
+       <if expr="_google_chrome">
+-        <if expr="not is_android or is_desktop_android">
++        <if expr="not is_android or is_desktop_android_thorium">
+           <!-- Desktop Android supports extensions and the web store. -->
+           <structure type="chrome_scaled_image" name="IDR_WEBSTORE_ICON" file="google_chrome/webstore_icon.png" />
+           <structure type="chrome_scaled_image" name="IDR_WEBSTORE_ICON_16" file="google_chrome/webstore_icon_16.png" />
+diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -7613,7 +7613,7 @@ static_library("browser") {
+     deps += [ "//media/mojo/mojom:remoting" ]
+   }
+ 
+-  if (is_android && !enable_desktop_android_extensions) {
++  if (is_android && !enable_desktop_android_extensions_thorium) {
+     sources += [ "download/download_crx_util_android.cc" ]
+   }
+ 
+@@ -7944,7 +7944,7 @@ static_library("browser") {
+ 
+   # TODO(https://crbug.com/356905053): Add more dependencies here and merge this
+   # block with the `enable_extensions` block above.
+-  if (enable_desktop_android_extensions) {
++  if (enable_desktop_android_extensions_thorium) {
+     sources += [
+       # TODO(https://crbug.com/356905053): These files are temporary workarounds
+       # allow for a lightweight extensions runtime in desktop-android builds.
+@@ -8716,7 +8716,7 @@ static_library("browser_generated_files") {
+           [ "//chrome/browser/ui/webui/new_tab_page/foo:mojo_bindings" ]
+     }
+   }
+-  if (!is_android || is_desktop_android) {
++  if (!is_android || is_desktop_android_thorium) {
+     public_deps += [ "//chrome/browser/ui/webui/discards:mojo_bindings" ]
+   }
+ 
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -375,6 +375,10 @@
+ #include "extensions/common/switches.h"
+ #endif  // BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+ 
++#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
++#include "extensions/common/extension_features.h"
++#endif
++
+ #if BUILDFLAG(ENABLE_PDF)
+ #include "pdf/pdf_features.h"
+ #endif
+diff --git a/chrome/browser/android/selection/chrome_selection_dropdown_menu_delegate.cc b/chrome/browser/android/selection/chrome_selection_dropdown_menu_delegate.cc
+--- a/chrome/browser/android/selection/chrome_selection_dropdown_menu_delegate.cc
++++ b/chrome/browser/android/selection/chrome_selection_dropdown_menu_delegate.cc
+@@ -8,7 +8,7 @@
+ #include "content/public/browser/render_frame_host.h"
+ #include "extensions/buildflags/buildflags.h"
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ #include "chrome/browser/extensions/extension_menu_model_android.h"
+ #endif  // BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
+ 
+@@ -25,7 +25,7 @@ std::unique_ptr<ui::MenuModel>
+ ChromeSelectionDropdownMenuDelegate::GetSelectionPopupExtraItems(
+     content::RenderFrameHost& render_frame_host,
+     const content::ContextMenuParams& params) {
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   std::unique_ptr<extensions::ExtensionMenuModel> extension_menu_model =
+       std::make_unique<extensions::ExtensionMenuModel>(render_frame_host,
+                                                        params);
+diff --git a/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarUtils.java b/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarUtils.java
+--- a/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarUtils.java
++++ b/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarUtils.java
+@@ -212,7 +212,7 @@ public class BookmarkBarUtils {
+         // On Desktop, we sync with the UserPrefs.
+         // On tablets we use the device preference logic (policy (pref service)  > local pref
+         // (shared pref) > FeatureParam).
+-        return DeviceInfo.isDesktop()
++        return DeviceInfo.isDesktopFalse()
+                 ? isUserPrefsShowBookmarksBarEnabled(profile)
+                 : isDevicePrefShowBookmarksBarEnabled(profile);
+     }
+@@ -431,13 +431,13 @@ public class BookmarkBarUtils {
+         boolean isCurrentlyVisible = isBookmarkBarVisible(context, profile, isXrFullSpaceMode);
+ 
+         // Record if the Bookmark Bar is visible, but not in cases of a forced feature param.
+-        if (DeviceInfo.isDesktop() || hasUserSetDevicePrefShowBookmarksBar()) {
++        if (DeviceInfo.isDesktopFalse() || hasUserSetDevicePrefShowBookmarksBar()) {
+             RecordHistogram.recordBooleanHistogram(
+                     BOOKMARK_BAR_SHOWN_ON_START_UP, isCurrentlyVisible);
+         }
+ 
+         // Record the reason why the Bookmark Bar is visible (hidden) in this instance.
+-        if (DeviceInfo.isDesktop()) {
++        if (DeviceInfo.isDesktopFalse()) {
+             RecordHistogram.recordEnumeratedHistogram(
+                     BOOKMARK_BAR_SHOWN_ON_START_UP_REASON,
+                     isCurrentlyVisible
+diff --git a/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarVisibilityProvider.java b/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarVisibilityProvider.java
+--- a/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarVisibilityProvider.java
++++ b/chrome/browser/bookmarks/android/java/src/org/chromium/chrome/browser/bookmarks/bar/BookmarkBarVisibilityProvider.java
+@@ -100,7 +100,7 @@ public class BookmarkBarVisibilityProvider {
+         mXrSpaceModeObservableSupplier.addSyncObserverAndPostIfNonNull(mXrSpaceModeObserver);
+ 
+         // On tablets we use local device prefs.
+-        if (!DeviceInfo.isDesktop()) {
++        if (!DeviceInfo.isDesktopFalse()) {
+             mDevicePrefsListener =
+                     (sharedPreferences, key) -> {
+                         if (key != null
+diff --git a/chrome/browser/browser_controls/android/java/src/org/chromium/chrome/browser/browser_controls/BrowserControlsUtils.java b/chrome/browser/browser_controls/android/java/src/org/chromium/chrome/browser/browser_controls/BrowserControlsUtils.java
+--- a/chrome/browser/browser_controls/android/java/src/org/chromium/chrome/browser/browser_controls/BrowserControlsUtils.java
++++ b/chrome/browser/browser_controls/android/java/src/org/chromium/chrome/browser/browser_controls/BrowserControlsUtils.java
+@@ -43,7 +43,7 @@ public class BrowserControlsUtils {
+             return false;
+         }
+ 
+-        return DeviceInfo.isDesktop()
++        return DeviceInfo.isDesktopFalse()
+                 || DeviceFormFactor.isNonMultiDisplayContextOnLargeTablet(context);
+     }
+ 
+diff --git a/chrome/browser/browser_process_impl.cc b/chrome/browser/browser_process_impl.cc
+--- a/chrome/browser/browser_process_impl.cc
++++ b/chrome/browser/browser_process_impl.cc
+@@ -387,7 +387,7 @@ void BrowserProcessImpl::Init() {
+   // TODO(devlin): Move this block out of BrowserProcessImpl to somewhere like
+   // //chrome/browser/initialize_extensions_browser_client, analogous to
+   // `EnsureExtensionsClientInitialized()` above?
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   extensions_browser_client_ = startup_data()->TakeExtensionsBrowserClient();
+ #elif BUILDFLAG(ENABLE_EXTENSIONS)
+   extensions_browser_client_ =
+diff --git a/chrome/browser/chrome_browser_field_trials.cc b/chrome/browser/chrome_browser_field_trials.cc
+--- a/chrome/browser/chrome_browser_field_trials.cc
++++ b/chrome/browser/chrome_browser_field_trials.cc
+@@ -124,7 +124,7 @@ void ChromeBrowserFieldTrials::RegisterFeatureOverrides(
+     feature_overrides.DisableFeature(features::kEyeDropper);
+   }
+ #elif BUILDFLAG(IS_ANDROID)  // BUILDFLAG(IS_LINUX)
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   // Nota bene: Anything here is expected to be short-lived, unless deemed too
+   // risky to launch to non-desktop platforms. New features being added here
+   // should be the exception, and not the norm. Instead, you should place the
+@@ -133,7 +133,7 @@ void ChromeBrowserFieldTrials::RegisterFeatureOverrides(
+ 
+   // Enable the link hover status bar.
+   // TODO(crbug.com/404678510): Remove when the feature is stable.
+-  feature_overrides.EnableFeature(chrome::android::kLinkHoverStatusBar);
++  // feature_overrides.EnableFeature(chrome::android::kLinkHoverStatusBar);
+ 
+   // If enabled, render processes associated only with tabs in unfocused windows
+   // will be downgraded to "vis" priority, rather than remaining at "fg". This
+@@ -144,24 +144,24 @@ void ChromeBrowserFieldTrials::RegisterFeatureOverrides(
+   // Enable desktop tab management features.
+   // TODO(crbug.com/422902625): Remove when rollout is complete to all form
+   // factors.
+-  feature_overrides.EnableFeature(chrome::android::kProcessRankPolicyAndroid);
+-  feature_overrides.EnableFeature(chrome::android::kProtectedTabsAndroid);
+-  feature_overrides.EnableFeature(features::kSubframeImportance);
++  // feature_overrides.EnableFeature(chrome::android::kProcessRankPolicyAndroid); have dangling ptr issue on shutdown
++  // feature_overrides.EnableFeature(chrome::android::kProtectedTabsAndroid);
++  // feature_overrides.EnableFeature(features::kSubframeImportance);
+   // TODO(crbug.com/465596248): Remove when experiment is complete.
+-  feature_overrides.EnableFeature(chrome::android::kProtectRecentlyVisibleTab);
++  // feature_overrides.EnableFeature(chrome::android::kProtectRecentlyVisibleTab);
+   // TODO(crbug.com/422903297): Remove when tablet rollout is complete.
+-  feature_overrides.EnableFeature(features::kRendererProcessLimitOnAndroid);
++  // feature_overrides.EnableFeature(features::kRendererProcessLimitOnAndroid);
+   // Enable V8 optimizations for high-end Android Desktop devices.
+   // TODO(crbug.com/425860368): Remove when the feature is stable.
+-  feature_overrides.EnableFeature(features::kV8AndroidDesktopHighEndConfig);
++  // feature_overrides.EnableFeature(features::kV8AndroidDesktopHighEndConfig);
+   // TODO(crbug.com/430304112): Remove when rollout is complete to all form
+   // factors.
+-  feature_overrides.EnableFeature(
+-      autofill::features::kAutofillAndroidDesktopSuppressAccessoryOnEmpty);
++  // feature_overrides.EnableFeature(
++  //     autofill::features::kAutofillAndroidDesktopSuppressAccessoryOnEmpty);
+   // TODO(crbug.com/436900619): Remove when the long term solution is
+   // implemented.
+-  feature_overrides.EnableFeature(
+-      chrome::android::kLockTopControlsOnLargeTablets);
++  // feature_overrides.EnableFeature(
++  //     chrome::android::kLockTopControlsOnLargeTablets);
+   // TODO(crbug.com/445446479): Remove when rollout is complete to all form
+   // factors.
+   feature_overrides.EnableFeature(
+@@ -169,13 +169,13 @@ void ChromeBrowserFieldTrials::RegisterFeatureOverrides(
+   // Bypass the WebAudio output buffer, to reduce audio latency.
+   // TODO(crbug.com/436988695): Remove when the long term solution is
+   // implemented.
+-  feature_overrides.EnableFeature(
+-      blink::features::kWebAudioBypassOutputBuffering);
++  // feature_overrides.EnableFeature(
++  //     blink::features::kWebAudioBypassOutputBuffering);
+   // TODO(crbug.com/437004266): Remove when the feature is stable.
+-  feature_overrides.EnableFeature(
+-      features::kAlwaysUseAudioManagerOutputFramesPerBuffer);
++  // feature_overrides.EnableFeature(
++  //     features::kAlwaysUseAudioManagerOutputFramesPerBuffer);
+   // TODO(crbug.com/440210010): Remove when the feature experiment is done.
+-  feature_overrides.EnableFeature(features::kAudioStereoInputStreamParameters);
++  // feature_overrides.EnableFeature(features::kAudioStereoInputStreamParameters);
+   // Enables automatic picture-in-picture.
+   // TODO(crbug.com/421608904): Remove when rollout is complete to all form
+   // factors.
+@@ -186,47 +186,47 @@ void ChromeBrowserFieldTrials::RegisterFeatureOverrides(
+   feature_overrides.EnableFeature(media::kContextMenuPictureInPictureAndroid);
+   // Disables the enhanced pip transition and uses the default animation.
+   // TODO(crbug.com/440384447): Remove when enhanced pip transition is fixed.
+-  feature_overrides.DisableFeature(media::kAllowEnhancedPipTransition);
++  // feature_overrides.DisableFeature(media::kAllowEnhancedPipTransition);
+   // Enable by default for desktop platforms, pending a phone / foldable /
+   // tablet rollout using the same flag.
+   // TODO(crbug.com/442327273): Remove when rollout is complete to all form
+   // factors.
+-  feature_overrides.EnableFeature(
+-      autofill::features::kAutofillAndroidDesktopKeyboardAccessoryRevamp);
++  // feature_overrides.EnableFeature(
++  //     autofill::features::kAutofillAndroidDesktopKeyboardAccessoryRevamp);
+   // Enable by default for desktop platforms, pending a tablet rollout using the
+   // same flag.
+   // TODO(crbug.com/445475304): Remove when tablet rollout is complete.
+   feature_overrides.EnableFeature(feed::kAndroidOpenIncognitoAsWindow);
+   // TODO(crbug.com/427242080): Remove when tablet rollout is complete.
+-  feature_overrides.EnableFeature(
+-      chrome::android::kAndroidPinnedTabsTabletTabStrip);
++  // feature_overrides.EnableFeature(
++  //     chrome::android::kAndroidPinnedTabsTabletTabStrip);
+ 
+   // Enable ANGLE/Vulkan features.
+   // TODO (crbug.com//376280554): Enable these features with runtime checks
+   // instead.
+-  feature_overrides.EnableFeature(::features::kSkipVulkanBlocklist);
+-  feature_overrides.EnableFeature(::features::kDefaultANGLEVulkan);
+-  feature_overrides.EnableFeature(::features::kVulkanFromANGLE);
+-  feature_overrides.EnableFeature(::features::kDefaultPassthroughCommandDecoder);
++  // feature_overrides.EnableFeature(::features::kSkipVulkanBlocklist);
++  // feature_overrides.EnableFeature(::features::kDefaultANGLEVulkan);
++  // feature_overrides.EnableFeature(::features::kVulkanFromANGLE);
++  // feature_overrides.EnableFeature(::features::kDefaultPassthroughCommandDecoder);
+ 
+   // Enable site-per-process by default for desktop platforms.
+   // TODO(crbug.com/453856709): Remove when we determine how to ensure
+   // SitePerProcess is enabled for all necessary or eligible Android devices.
+-  feature_overrides.EnableFeature(::features::kSitePerProcess);
++  // feature_overrides.EnableFeature(::features::kSitePerProcess);
+ 
+   // Enable all tabs to have WebContents at all times for desktop platforms.
+   // TODO(crbug.com/448420873): Remove once we enable this feature for all form
+   // factors. This is currently blocked by performance regressions on low-end
+   // Android devices.
+-  feature_overrides.EnableFeature(features::kWebContentsDiscard);
+-  feature_overrides.EnableFeature(features::kLazyBrowserInterfaceBroker);
+-  feature_overrides.EnableFeature(chrome::android::kTabFreezingUsesDiscard);
+-  feature_overrides.EnableFeature(chrome::android::kLoadAllTabsAtStartup);
++  // feature_overrides.EnableFeature(features::kWebContentsDiscard);
++  // feature_overrides.EnableFeature(features::kLazyBrowserInterfaceBroker);
++  // feature_overrides.EnableFeature(chrome::android::kTabFreezingUsesDiscard);
++  // feature_overrides.EnableFeature(chrome::android::kLoadAllTabsAtStartup);
+ 
+   // Enable the ability for extensions to override chrome pages.
+   // TODO(crbug.com/404069963): Remove flag when the feature is verified to be
+   // stable on desktop Android.
+-  feature_overrides.EnableFeature(chrome::android::kChromeNativeUrlOverriding);
++  // feature_overrides.EnableFeature(chrome::android::kChromeNativeUrlOverriding);
+ 
+   // Enable desktop full screen to a screen feature flag by default for desktop
+   // platforms.
+@@ -238,7 +238,7 @@ void ChromeBrowserFieldTrials::RegisterFeatureOverrides(
+   // Enables the ability to specify a platform-specific zoom scaling that will
+   // apply transparently to all pages.
+   // TODO(crbug.com/450281745): Remove once feature is enabled by default.
+-  feature_overrides.EnableFeature(::features::kAndroidDesktopZoomScaling);
++  // feature_overrides.EnableFeature(::features::kAndroidDesktopZoomScaling);
+ #endif  // BUILDFLAG(IS_DESKTOP_ANDROID)
+   // Desktop-first features which are past incubation should either end up here,
+   // or to a finch trial that enables it for all form factors.
+diff --git a/chrome/browser/chrome_browser_interface_binders_webui.cc b/chrome/browser/chrome_browser_interface_binders_webui.cc
+--- a/chrome/browser/chrome_browser_interface_binders_webui.cc
++++ b/chrome/browser/chrome_browser_interface_binders_webui.cc
+@@ -44,7 +44,7 @@
+ #include "mojo/public/cpp/bindings/binder_map.h"
+ 
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
++    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ #include "chrome/browser/ui/webui/discards/discards.mojom.h"
+ #include "chrome/browser/ui/webui/discards/discards_ui.h"
+ #include "chrome/browser/ui/webui/discards/site_data.mojom.h"
+@@ -153,7 +153,7 @@ void PopulateChromeWebUIFrameBinders(
+ #endif  // BUILDFLAG(IS_CHROMEOS)
+ 
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
++    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   RegisterWebUIControllerInterfaceBinder<discards::mojom::DetailsProvider,
+                                          DiscardsUI>(map);
+ 
+diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -4307,7 +4307,7 @@ base::OnceClosure ChromeContentBrowserClient::SelectClientCertificate(
+     // TODO(wenz): This should instead proceed with the selected certificate
+     // when there are matching certificates in the OS.
+ #if BUILDFLAG(ENABLE_EXTENSIONS) && \
+-    !(BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID))
++    !(BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM))
+     if (matching_certificates.empty() && nonmatching_certificates.empty()) {
+       extensions::ProcessMap* process_map =
+           extensions::ProcessMap::Get(profile);
+@@ -4539,7 +4539,7 @@ void ChromeContentBrowserClient::OverrideWebPreferences(
+ // Fill font preferences. These are not registered on Android unless we're built
+ // with extensions (the chrome.fontSettings API can change these).
+ // - http://crbug.com/40337093, http://crbug.com/41304476.
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // Enabling the FontFamilyCache needs some KeyedService that might not be
+   // available for some irregular profiles, like the System Profile.
+   if (!AreKeyedServicesDisabledForProfileByDefault(profile)) {
+diff --git a/chrome/browser/devtools/BUILD.gn b/chrome/browser/devtools/BUILD.gn
+--- a/chrome/browser/devtools/BUILD.gn
++++ b/chrome/browser/devtools/BUILD.gn
+@@ -354,7 +354,7 @@ static_library("devtools") {
+     }
+   }
+ 
+-  if (!is_android || enable_desktop_android_extensions) {
++  if (!is_android || enable_desktop_android_extensions_thorium) {
+     sources += [
+       "global_confirm_info_bar.cc",
+       "global_confirm_info_bar.h",
+diff --git a/chrome/browser/download/chrome_download_manager_delegate.cc b/chrome/browser/download/chrome_download_manager_delegate.cc
+--- a/chrome/browser/download/chrome_download_manager_delegate.cc
++++ b/chrome/browser/download/chrome_download_manager_delegate.cc
+@@ -749,7 +749,7 @@ bool ChromeDownloadManagerDelegate::DetermineDownloadTarget(
+   DownloadPathReservationTracker::FilenameConflictAction action =
+       kDefaultPlatformConflictAction;
+ #if BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     action = DownloadPathReservationTracker::UNIQUIFY;
+   }
+ 
+diff --git a/chrome/browser/download/download_offline_content_provider.cc b/chrome/browser/download/download_offline_content_provider.cc
+--- a/chrome/browser/download/download_offline_content_provider.cc
++++ b/chrome/browser/download/download_offline_content_provider.cc
+@@ -46,7 +46,7 @@
+ #include "content/public/common/content_features.h"
+ #include "ui/base/device_form_factor.h"
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ #include "chrome/browser/download/download_core_service.h"
+ #include "chrome/browser/download/download_core_service_factory.h"
+ #endif
+@@ -489,7 +489,7 @@ void DownloadOfflineContentProvider::OnDownloadUpdated(DownloadItem* item) {
+     return;
+   }
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // On desktop Android, the extensions chrome.download.setUiOptions() function
+   // can disable UI updates.
+   // TODO(crbug.com/459823225): Expand the IsDangerous() check to other
+diff --git a/chrome/browser/extensions/BUILD.gn b/chrome/browser/extensions/BUILD.gn
+--- a/chrome/browser/extensions/BUILD.gn
++++ b/chrome/browser/extensions/BUILD.gn
+@@ -1735,7 +1735,7 @@ source_set("chrome_extensions_browser_client") {
+     "//extensions/browser/updater",
+   ]
+ 
+-  if (enable_desktop_android_extensions) {
++  if (enable_desktop_android_extensions_thorium) {
+     sources += [ "chrome_extensions_browser_client_android.cc" ]
+ 
+     deps += [
+@@ -1750,6 +1750,16 @@ source_set("chrome_extensions_browser_client") {
+       "//extensions/browser",
+       "//extensions/browser/kiosk",
+     ]
++
++    ### Extensions API module start
++    sources += [
++      "api/adblock_private/adblock_private_api.cc",
++      "api/adblock_private/adblock_private_api.h",
++      "api/eyeo_filtering_private/eyeo_filtering_private_api.cc",
++      "api/eyeo_filtering_private/eyeo_filtering_private_api.h",
++    ]
++
++    deps += [ "//components/adblock/content:browser" ]
+   }
+ 
+   if (enable_extensions) {
+diff --git a/chrome/browser/extensions/api/chrome_extensions_api_client_android.cc b/chrome/browser/extensions/api/chrome_extensions_api_client_android.cc
+--- a/chrome/browser/extensions/api/chrome_extensions_api_client_android.cc
++++ b/chrome/browser/extensions/api/chrome_extensions_api_client_android.cc
+@@ -15,7 +15,7 @@
+ // The stubs are implemented here instead of falling back to ExtensionsAPIClient
+ // to allow NOTIMPLEMENTED() logging and a place to put TODOs with bug IDs.
+ 
+-static_assert(BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS));
++static_assert(BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE));
+ 
+ namespace extensions {
+ 
+diff --git a/chrome/browser/extensions/api/identity/web_auth_flow.cc b/chrome/browser/extensions/api/identity/web_auth_flow.cc
+--- a/chrome/browser/extensions/api/identity/web_auth_flow.cc
++++ b/chrome/browser/extensions/api/identity/web_auth_flow.cc
+@@ -38,7 +38,7 @@
+ #include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/browser_window.h"
+ #else
+-static_assert(BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS));
++static_assert(BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE));
+ #include "base/functional/callback_forward.h"
+ #include "chrome/browser/android/tab_android.h"
+ #include "chrome/browser/tab_list/tab_list_interface.h"
+@@ -166,7 +166,7 @@ void WebAuthFlow::CloseInfoBar() {
+   }
+ }
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ void WebAuthFlow::OnBrowserWindowInterfaceInitialized(
+     BrowserWindowInterface* browser) {
+   TabModel* tab_model =
+@@ -202,7 +202,7 @@ bool WebAuthFlow::DisplayAuthPageInPopupWindow() {
+ 
+   browser->window()->Show();
+ #else
+-  static_assert(BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS));
++  static_assert(BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE));
+   BrowserWindowCreateParams params(BrowserWindowInterface::TYPE_POPUP,
+                                    *profile_, user_gesture_);
+   if (popup_bounds_.has_value()) {
+diff --git a/chrome/browser/extensions/api/identity/web_auth_flow.h b/chrome/browser/extensions/api/identity/web_auth_flow.h
+--- a/chrome/browser/extensions/api/identity/web_auth_flow.h
++++ b/chrome/browser/extensions/api/identity/web_auth_flow.h
+@@ -149,7 +149,7 @@ class WebAuthFlow : public content::WebContentsObserver,
+   void MaybeStartTimeout();
+   void OnTimeout();
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   void OnBrowserWindowInterfaceInitialized(BrowserWindowInterface* browser);
+ #endif
+ 
+@@ -195,7 +195,7 @@ class WebAuthFlow : public content::WebContentsObserver,
+   // the error code when the flow times out.
+   bool initial_url_loaded_ = false;
+   base::ScopedObservation<Profile, ProfileObserver> profile_observation_{this};
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   base::WeakPtrFactory<WebAuthFlow> weak_factory_{this};
+ #endif
+ };
+diff --git a/chrome/browser/extensions/api/tabs/tabs_event_router.cc b/chrome/browser/extensions/api/tabs/tabs_event_router.cc
+--- a/chrome/browser/extensions/api/tabs/tabs_event_router.cc
++++ b/chrome/browser/extensions/api/tabs/tabs_event_router.cc
+@@ -338,6 +338,9 @@ void TabsEventRouter::DispatchEvent(
+ 
+ void TabsEventRouter::OnTabAdded(tabs::TabInterface* tab, int index) {
+   content::WebContents* contents = tab->GetContents();
++#if BUILDFLAG(IS_ANDROID)
++  if (!contents) return;
++#endif
+   CHECK(contents);
+ 
+   // Check if we've ever seen this tab.
+diff --git a/chrome/browser/extensions/extension_management.cc b/chrome/browser/extensions/extension_management.cc
+--- a/chrome/browser/extensions/extension_management.cc
++++ b/chrome/browser/extensions/extension_management.cc
+@@ -177,8 +177,12 @@ ManagedInstallationMode ExtensionManagement::GetInstallationMode(
+                              update_url ? *update_url : std::string());
+ }
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ bool ExtensionManagement::ExtensionsEnabledForDesktopAndroid() const {
++  if ((true)) {
++    return base::FeatureList::IsEnabled(
++            extensions_features::kEnableExtensionsAndroid);
++  }
+   // If Finch has enabled extensions for corp, allow them.
+   if (base::FeatureList::IsEnabled(
+           extensions_features::kEnableExtensionsForCorpDesktopAndroid)) {
+@@ -201,7 +205,7 @@ bool ExtensionManagement::ExtensionsEnabledForDesktopAndroid() const {
+ ManagedInstallationMode ExtensionManagement::GetInstallationMode(
+     const ExtensionId& extension_id,
+     const std::string& update_url) {
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // Block extensions for managed profiles on Desktop Android. This is
+   // temporary until extensions are ready for dogfooding.
+   // TODO(crbug.com/422307625): Remove this check once extensions are ready for
+diff --git a/chrome/browser/extensions/extension_management.h b/chrome/browser/extensions/extension_management.h
+--- a/chrome/browser/extensions/extension_management.h
++++ b/chrome/browser/extensions/extension_management.h
+@@ -103,7 +103,7 @@ class ExtensionManagement : public KeyedService,
+   const std::vector<std::unique_ptr<ManagementPolicy::Provider>>& GetProviders()
+       const;
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // Checks if extensions are enabled for Desktop Android for the current
+   // profile. This is temporary for until extensions are ready for dogfooding.
+   // TODO(crbug.com/422307625): Remove this check once extensions are ready for
+diff --git a/chrome/browser/extensions/extension_util.cc b/chrome/browser/extensions/extension_util.cc
+--- a/chrome/browser/extensions/extension_util.cc
++++ b/chrome/browser/extensions/extension_util.cc
+@@ -50,6 +50,10 @@
+ #include "chromeos/ash/components/file_manager/app_id.h"
+ #endif
+ 
++#if BUILDFLAG(IS_ANDROID)
++#include "extensions/common/extension_features.h"
++#endif
++
+ static_assert(BUILDFLAG(ENABLE_EXTENSIONS_CORE));
+ 
+ namespace extensions::util {
+@@ -350,6 +354,13 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+ 
+ bool AreExtensionsDisabled(const base::CommandLine& command_line,
+                            content::BrowserContext* context) {
++#if BUILDFLAG(IS_ANDROID)
++  if (!base::FeatureList::IsEnabled(
++            extensions_features::kEnableExtensionsAndroid)) {
++    LOG(INFO) << "Extensions are disabled";
++    return true;
++  }
++#endif
+   Profile* profile = Profile::FromBrowserContext(context);
+   return ExtensionsDisabledViaCommandLine(command_line) ||
+          profile->GetPrefs()->GetBoolean(prefs::kDisableExtensions);
+diff --git a/chrome/browser/feedback/android/java/src/org/chromium/chrome/browser/feedback/DeviceInfoFeedbackSource.java b/chrome/browser/feedback/android/java/src/org/chromium/chrome/browser/feedback/DeviceInfoFeedbackSource.java
+--- a/chrome/browser/feedback/android/java/src/org/chromium/chrome/browser/feedback/DeviceInfoFeedbackSource.java
++++ b/chrome/browser/feedback/android/java/src/org/chromium/chrome/browser/feedback/DeviceInfoFeedbackSource.java
+@@ -36,7 +36,7 @@ class DeviceInfoFeedbackSource implements FeedbackSource {
+             type = TYPE_AUTO;
+         } else if (DeviceInfo.isXr()) {
+             type = TYPE_XR;
+-        } else if (DeviceInfo.isDesktop()) {
++        } else if (DeviceInfo.isDesktopFalse()) {
+             type = TYPE_DESKTOP;
+         } else if (DeviceFormFactor.isNonMultiDisplayContextOnTablet(
+                 ContextUtils.getApplicationContext())) {
+diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+--- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
++++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+@@ -757,7 +757,7 @@ public abstract class ChromeFeatureList {
+     public static final CachedFlag sAndroidNewMediaPicker =
+             newCachedFlag(ANDROID_NEW_MEDIA_PICKER, false);
+     public static final CachedFlag sAndroidOpenIncognitoAsWindow =
+-            newCachedFlag(ANDROID_OPEN_INCOGNITO_AS_WINDOW, BuildConfig.IS_DESKTOP_ANDROID, true);
++            newCachedFlag(ANDROID_OPEN_INCOGNITO_AS_WINDOW, BuildConfig.IS_DESKTOP_ANDROID_FALSE, false);
+     public static final CachedFlag sAndroidProgressBarVisualUpdate =
+             newCachedFlag(
+                     ANDROID_PROGRESS_BAR_VISUAL_UPDATE,
+@@ -884,7 +884,7 @@ public abstract class ChromeFeatureList {
+     public static final CachedFlag sChromeItemPickerUi =
+             newCachedFlag(CHROME_ITEM_PICKER_UI, /* defaultValue= */ false);
+     public static final CachedFlag sChromeNativeUrlOverriding =
+-            newCachedFlag(CHROME_NATIVE_URL_OVERRIDING, BuildConfig.IS_DESKTOP_ANDROID);
++            newCachedFlag(CHROME_NATIVE_URL_OVERRIDING, BuildConfig.IS_DESKTOP_ANDROID_FALSE);
+     public static final CachedFlag sClampAutomotiveScaling =
+             newCachedFlag(CLAMP_AUTOMOTIVE_SCALING, true);
+     public static final CachedFlag sClankStartupLatencyInjection =
+@@ -1040,7 +1040,7 @@ public abstract class ChromeFeatureList {
+             newCachedFlag(POWER_SAVING_MODE_BROADCAST_RECEIVER_IN_BACKGROUND, true);
+     public static final CachedFlag sPriceChangeModule = newCachedFlag(PRICE_CHANGE_MODULE, true);
+     public static final CachedFlag sProtectRecentlyVisibleTab =
+-            newCachedFlag(PROTECT_RECENTLY_VISIBLE_TAB, BuildConfig.IS_DESKTOP_ANDROID);
++            newCachedFlag(PROTECT_RECENTLY_VISIBLE_TAB, BuildConfig.IS_DESKTOP_ANDROID_THORIUM);
+     public static final CachedFlag sReportNotificationContentDetectionData =
+             newCachedFlag(
+                     REPORT_NOTIFICATION_CONTENT_DETECTION_DATA,
+diff --git a/chrome/browser/media/router/BUILD.gn b/chrome/browser/media/router/BUILD.gn
+--- a/chrome/browser/media/router/BUILD.gn
++++ b/chrome/browser/media/router/BUILD.gn
+@@ -261,7 +261,7 @@ static_library("test_support") {
+   deps = []
+   sources = []
+ 
+-  if (!is_android || is_desktop_android) {
++  if (!is_android || is_desktop_android_thorium) {
+     deps += [
+       "//base",
+       "//chrome/browser/media/router/discovery",
+@@ -412,7 +412,7 @@ source_set("unittests") {
+   }
+ 
+   # Traditional desktop platforms and desktop android with extensions support.
+-  if (!is_android || enable_desktop_android_extensions) {
++  if (!is_android) { # || enable_desktop_android_extensions) {
+     deps += [ "//chrome/browser/media/router/discovery:test_support" ]
+   }
+ 
+diff --git a/chrome/browser/media/router/discovery/BUILD.gn b/chrome/browser/media/router/discovery/BUILD.gn
+--- a/chrome/browser/media/router/discovery/BUILD.gn
++++ b/chrome/browser/media/router/discovery/BUILD.gn
+@@ -4,7 +4,7 @@
+ 
+ import("//build/config/chrome_build.gni")
+ 
+-assert(!is_android || is_desktop_android, "Not supported on mobile")
++assert(!is_android || is_desktop_android_thorium, "Not supported on mobile")
+ assert(!is_fuchsia, "Fuchsia shouldn't use anything in //chrome")
+ 
+ static_library("discovery") {
+diff --git a/chrome/browser/media/router/media_router_feature.cc b/chrome/browser/media/router/media_router_feature.cc
+--- a/chrome/browser/media/router/media_router_feature.cc
++++ b/chrome/browser/media/router/media_router_feature.cc
+@@ -30,7 +30,7 @@
+ #include "extensions/buildflags/buildflags.h"
+ #include "ui/base/buildflags.h"
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ #include "components/prefs/pref_registry_simple.h"
+ #endif
+ 
+@@ -43,7 +43,7 @@
+ 
+ namespace media_router {
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ BASE_FEATURE(kMediaRouter, base::FEATURE_ENABLED_BY_DEFAULT);
+ BASE_FEATURE(kCastAllowAllIPsFeature,
+              "CastAllowAllIPs",
+@@ -82,7 +82,7 @@ base::flat_map<content::BrowserContext*, bool>& GetStoredPrefValues() {
+   return *stored_pref_values;
+ }
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ // TODO(mfoltz): Add full implementation for validating playout delay value.
+ bool IsValidMirroringPlayoutDelayMs(int delay_ms) {
+   return delay_ms <= 1000 && delay_ms >= 1;
+@@ -97,7 +97,7 @@ void ClearMediaRouterStoredPrefsForTesting() {
+ 
+ bool MediaRouterEnabled(content::BrowserContext* context) {
+   if ((true)) return false;
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+   if (!base::FeatureList::IsEnabled(kMediaRouter)) {
+     return false;
+   }
+@@ -132,7 +132,7 @@ bool MediaRouterEnabled(content::BrowserContext* context) {
+   return true;
+ }
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
+   registry->RegisterBooleanPref(prefs::kMediaRouterCastAllowAllIPs, false,
+                                 PrefRegistry::PUBLIC);
+diff --git a/chrome/browser/media/router/media_router_feature.h b/chrome/browser/media/router/media_router_feature.h
+--- a/chrome/browser/media/router/media_router_feature.h
++++ b/chrome/browser/media/router/media_router_feature.h
+@@ -27,7 +27,7 @@ bool MediaRouterEnabled(content::BrowserContext* context);
+ // process.
+ void ClearMediaRouterStoredPrefsForTesting();
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ // Enables the media router. Can be disabled in tests unrelated to
+ // Media Router where it interferes. Can also be useful to disable for local
+ // development on Mac because DIAL local discovery opens a local port
+diff --git a/chrome/browser/media/webrtc/webrtc_event_log_manager.cc b/chrome/browser/media/webrtc/webrtc_event_log_manager.cc
+--- a/chrome/browser/media/webrtc/webrtc_event_log_manager.cc
++++ b/chrome/browser/media/webrtc/webrtc_event_log_manager.cc
+@@ -113,7 +113,7 @@ class PeerConnectionTrackerProxyImpl
+ // necessarily for any given user profile.
+ // Certain platforms (mobile) are blocked from remote-bound logging.
+ bool IsRemoteLoggingFeatureEnabled() {
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+   bool enabled = false;
+ #else
+   bool enabled = true;
+@@ -465,7 +465,7 @@ WebRtcEventLogManager::CreateRemoteLogFileWriterFactory() {
+   if (remote_log_file_writer_factory_for_testing_) {
+     return std::move(remote_log_file_writer_factory_for_testing_);
+   } else {
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_DESKTOP_ANDROID)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+     return std::make_unique<GzippedLogFileWriterFactory>(
+         std::make_unique<GzipLogCompressorFactory>(
+             std::make_unique<DefaultGzippedSizeEstimator::Factory>()));
+diff --git a/chrome/browser/open_in_app/android/java/src/org/chromium/chrome/browser/open_in_app/OpenInAppUtils.java b/chrome/browser/open_in_app/android/java/src/org/chromium/chrome/browser/open_in_app/OpenInAppUtils.java
+--- a/chrome/browser/open_in_app/android/java/src/org/chromium/chrome/browser/open_in_app/OpenInAppUtils.java
++++ b/chrome/browser/open_in_app/android/java/src/org/chromium/chrome/browser/open_in_app/OpenInAppUtils.java
+@@ -14,7 +14,7 @@ public class OpenInAppUtils {
+ 
+     /** Returns whether Open in App is available. */
+     public static boolean isOpenInAppAvailable() {
+-        return ChromeFeatureList.sDesktopAndroidLinkCapturing.isEnabled() && DeviceInfo.isDesktop();
++        return ChromeFeatureList.sDesktopAndroidLinkCapturing.isEnabled() && DeviceInfo.isDesktopFalse();
+     }
+ 
+     private OpenInAppUtils() {}
+diff --git a/chrome/browser/policy/policy_value_and_status_aggregator.cc b/chrome/browser/policy/policy_value_and_status_aggregator.cc
+--- a/chrome/browser/policy/policy_value_and_status_aggregator.cc
++++ b/chrome/browser/policy/policy_value_and_status_aggregator.cc
+@@ -47,7 +47,7 @@
+ #include "chrome/browser/policy/status_provider/updater_status_and_value_provider.h"
+ #endif  // BUILDFLAG(IS_WIN) && BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ 
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
++#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+ #include "chrome/browser/policy/cloud/extension_install_policy_service_factory.h"
+ #include "chrome/browser/policy/value_provider/extension_install_policies_value_provider.h"
+ #include "chrome/browser/policy/value_provider/extension_policies_value_provider.h"
+diff --git a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
+--- a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
++++ b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
+@@ -655,7 +655,7 @@ void ChromeBrowserMainExtraPartsProfiles::
+   chromeos_extensions::EnsureBrowserContextKeyedServiceFactoriesBuilt();
+ #endif
+   extensions::EnsureBrowserContextKeyedServiceFactoriesBuilt();
+-#elif BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#elif BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   chrome_extensions::EnsureBrowserContextKeyedServiceFactoriesBuilt();
+   // EnsureBrowserContextKeyedServiceFactoriesBuilt() is invoked before the
+   // ExtensionsBrowserClient is ready on Android. This is due to Android
+diff --git a/chrome/browser/profiles/off_the_record_profile_impl.cc b/chrome/browser/profiles/off_the_record_profile_impl.cc
+--- a/chrome/browser/profiles/off_the_record_profile_impl.cc
++++ b/chrome/browser/profiles/off_the_record_profile_impl.cc
+@@ -108,6 +108,8 @@
+ #if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+ #include "chrome/browser/extensions/extension_special_storage_policy.h"
+ #include "chrome/browser/ui/webui/extensions/extension_icon_source.h"
++#include "extensions/browser/api/web_request/extension_web_request_event_router.h"
++#include "extensions/browser/process_manager.h"
+ #endif
+ 
+ #if BUILDFLAG(ENABLE_EXTENSIONS)
+@@ -216,7 +218,10 @@ void OffTheRecordProfileImpl::Init() {
+       this, std::make_unique<extensions::ExtensionIconSource>(profile_));
+ #endif
+ 
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
++#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
++  if (extensions::ProcessManager* process_manager = extensions::ProcessManager::Get(this)) {
++    process_manager->MaybeCreateStartupBackgroundHosts();
++  }
+   extensions::WebRequestEventRouter::OnOTRBrowserContextCreated(profile_, this);
+ #endif
+ 
+@@ -275,7 +280,7 @@ OffTheRecordProfileImpl::~OffTheRecordProfileImpl() {
+ 
+   SimpleKeyMap::GetInstance()->Dissociate(this);
+ 
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
++#if BUILDFLAG(ENABLE_EXTENSIONS_CORE)
+   extensions::WebRequestEventRouter::OnOTRBrowserContextDestroyed(profile_,
+                                                                   this);
+ #endif
+diff --git a/chrome/browser/profiles/profile_destroyer.cc b/chrome/browser/profiles/profile_destroyer.cc
+--- a/chrome/browser/profiles/profile_destroyer.cc
++++ b/chrome/browser/profiles/profile_destroyer.cc
+@@ -29,7 +29,7 @@ namespace {
+ #if BUILDFLAG(IS_ANDROID)
+ // Set the render host waiting time to 5s on Android, that's the same
+ // as an "Application Not Responding" timeout.
+-const int64_t kTimerDelaySeconds = 5;
++const int64_t kTimerDelaySeconds = 1;
+ #elif BUILDFLAG(IS_CHROMEOS)
+ // linux-chromeos-dbg is failing to destroy the profile in under 1 second
+ const int64_t kTimerDelaySeconds = 2;
+diff --git a/chrome/browser/resources/BUILD.gn b/chrome/browser/resources/BUILD.gn
+--- a/chrome/browser/resources/BUILD.gn
++++ b/chrome/browser/resources/BUILD.gn
+@@ -126,7 +126,7 @@ group("resources") {
+     ]
+   }
+ 
+-  if (is_win || is_mac || is_linux || is_chromeos || is_desktop_android) {
++  if (is_win || is_mac || is_linux || is_chromeos || is_desktop_android_thorium) {
+     public_deps += [ "discards:resources" ]
+   }
+ 
+diff --git a/chrome/browser/resources/discards/BUILD.gn b/chrome/browser/resources/discards/BUILD.gn
+--- a/chrome/browser/resources/discards/BUILD.gn
++++ b/chrome/browser/resources/discards/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//ui/webui/resources/tools/build_webui.gni")
+ import("//ui/webui/resources/tools/generate_grd.gni")
+ 
+-assert(!is_android || is_desktop_android)
++assert(!is_android || is_desktop_android_thorium)
+ 
+ build_webui("build") {
+   grd_prefix = "discards"
+diff --git a/chrome/browser/resources/extensions/detail_view.css b/chrome/browser/resources/extensions/detail_view.css
+--- a/chrome/browser/resources/extensions/detail_view.css
++++ b/chrome/browser/resources/extensions/detail_view.css
+@@ -212,3 +212,9 @@ extensions-toggle-row {
+   display: flex;
+   flex-direction: row;
+ }
++
++<if expr="is_android">
++.page-content {
++  width: 100% !important;
++}
++</if>
+diff --git a/chrome/browser/resources/extensions/extensions.html b/chrome/browser/resources/extensions/extensions.html
+--- a/chrome/browser/resources/extensions/extensions.html
++++ b/chrome/browser/resources/extensions/extensions.html
+@@ -1,9 +1,15 @@
+ <!doctype html>
+ <html dir="$i18n{textdirection}" lang="$i18n{language}"
+-    class="loading $i18n{loadTimeClasses}">
++    class="loading $i18n{loadTimeClasses}"
++<if expr="is_android">
++  android
++</if>>
+ <head>
+   <meta charset="utf8">
+   <meta name="color-scheme" content="light dark">
++<if expr="is_android">
++  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=yes">
++</if>
+   <title>$i18n{title}</title>
+   <base href="chrome://extensions">
+   <link rel="stylesheet" href="chrome://resources/css/md_colors.css">
+diff --git a/chrome/browser/resources/extensions/item_list.css b/chrome/browser/resources/extensions/item_list.css
+--- a/chrome/browser/resources/extensions/item_list.css
++++ b/chrome/browser/resources/extensions/item_list.css
+@@ -10,7 +10,12 @@
+ 
+ .items-container,
+ #content-wrapper {
++<if expr="is_android">
++  --extensions-card-width: 90vw;
++</if>
++<if expr="not is_android">
+   --extensions-card-width: 400px;
++</if>
+ }
+ 
+ #container {
+@@ -20,7 +25,12 @@
+ 
+ #content-wrapper {
+   min-width: var(--extensions-card-width);
++<if expr="is_android">
++  padding: 0px !important;
++</if>
++<if expr="not is_android">
+   padding: 24px 60px 64px;
++</if>
+ }
+ 
+ #content-wrapper:has(extensions-review-panel),
+diff --git a/chrome/browser/resources/extensions/toolbar.html.ts b/chrome/browser/resources/extensions/toolbar.html.ts
+--- a/chrome/browser/resources/extensions/toolbar.html.ts
++++ b/chrome/browser/resources/extensions/toolbar.html.ts
+@@ -25,13 +25,6 @@ export function getHtml(this: ToolbarElement) {
+         aria-labelledby="devModeLabel">
+     </cr-toggle>
+   </div>
+-  <if expr="is_android">
+-    <picture slot="product-logo">
+-      <source media="(prefers-color-scheme: dark)"
+-          srcset="//resources/images/chrome_logo_dark.svg">
+-      <img srcset="images/product_logo.png" role="presentation">
+-    </picture>
+-  </if>
+   <div class="more-actions">
+     <span>$i18n{toolbarExtensionUpdateEnabled}
+       <span id="need-update" ?hidden="${!this.shouldShowRelaunchDialog}">$i18n{toolbarExtensionUpdateEnabledNeedRestart}</span>
+diff --git a/chrome/browser/sessions/session_restore_android.cc b/chrome/browser/sessions/session_restore_android.cc
+--- a/chrome/browser/sessions/session_restore_android.cc
++++ b/chrome/browser/sessions/session_restore_android.cc
+@@ -23,7 +23,7 @@
+ 
+ namespace {
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ BrowserWindowInterface::Type BrowserTypeFromWindowType(
+     sessions::SessionWindow::WindowType type) {
+   switch (type) {
+@@ -109,7 +109,7 @@ void SessionRestore::RestoreForeignSessionWindows(
+     std::vector<const sessions::SessionWindow*>::const_iterator begin,
+     std::vector<const sessions::SessionWindow*>::const_iterator end,
+     base::OnceCallback<void(std::vector<BrowserWindowInterface*>)> callback) {
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+   // The extensions sessions API can restore foreign windows.
+   size_t window_count = std::distance(begin, end);
+   // Wait for `window_count` callbacks.
+diff --git a/chrome/browser/share/android/java/src/org/chromium/chrome/browser/share/ChromeProvidedSharingOptionsProviderBase.java b/chrome/browser/share/android/java/src/org/chromium/chrome/browser/share/ChromeProvidedSharingOptionsProviderBase.java
+--- a/chrome/browser/share/android/java/src/org/chromium/chrome/browser/share/ChromeProvidedSharingOptionsProviderBase.java
++++ b/chrome/browser/share/android/java/src/org/chromium/chrome/browser/share/ChromeProvidedSharingOptionsProviderBase.java
+@@ -284,7 +284,7 @@ public abstract class ChromeProvidedSharingOptionsProviderBase {
+     }
+ 
+     private void maybeAddCollaborateFirstPartyOption() {
+-        if (DeviceInfo.isDesktop()) {
++        if (DeviceInfo.isDesktopFalse()) {
+             return;
+         }
+         FirstPartyOption option = createCollaborateFirstPartyOption();
+@@ -316,7 +316,7 @@ public abstract class ChromeProvidedSharingOptionsProviderBase {
+ 
+     private void maybeAddPrintFirstPartyOption() {
+         // For the desktop case, the Print action will be showed in the main menu.
+-        if (!DeviceInfo.isDesktop()
++        if (!DeviceInfo.isDesktopFalse()
+                 && mTabProvider.get() != null
+                 && UserPrefs.get(mProfile).getBoolean(Pref.PRINTING_ENABLED)) {
+             mOrderedFirstPartyOptions.add(createPrintingFirstPartyOption());
+diff --git a/chrome/browser/startup_data.cc b/chrome/browser/startup_data.cc
+--- a/chrome/browser/startup_data.cc
++++ b/chrome/browser/startup_data.cc
+@@ -51,7 +51,7 @@
+ #include "mojo/public/cpp/bindings/pending_remote.h"
+ #include "services/preferences/public/mojom/tracked_preference_validation_delegate.mojom.h"
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ #include "chrome/browser/extensions/chrome_extensions_browser_client.h"
+ #include "extensions/browser/extensions_browser_client.h"
+ #endif
+@@ -167,7 +167,7 @@ StartupData::TakeProtoDatabaseProvider() {
+ void StartupData::PreProfilePrefServiceInit() {
+   pref_registry_ = base::MakeRefCounted<user_prefs::PrefRegistrySyncable>();
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // On desktop Android the ExtensionsBrowserClient is created here because it
+   // must be initialized before BrowserContextKeyedServiceFactories are built.
+   // Some factories use ExtensionsBrowserClient::Get() in their DependsOn().
+@@ -249,7 +249,7 @@ void StartupData::CreateServicesInternal() {
+ }
+ #endif
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ std::unique_ptr<extensions::ExtensionsBrowserClient>
+ StartupData::TakeExtensionsBrowserClient() {
+   return std::move(extensions_browser_client_);
+diff --git a/chrome/browser/startup_data.h b/chrome/browser/startup_data.h
+--- a/chrome/browser/startup_data.h
++++ b/chrome/browser/startup_data.h
+@@ -12,7 +12,7 @@
+ #include "components/leveldb_proto/public/proto_database_provider.h"
+ #include "extensions/buildflags/buildflags.h"
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ namespace extensions {
+ class ExtensionsBrowserClient;
+ }
+@@ -92,7 +92,7 @@ class StartupData {
+   TakeProtoDatabaseProvider();
+ #endif
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // Passes ownership of the `extensions_browser_client_` to the caller.
+   std::unique_ptr<extensions::ExtensionsBrowserClient>
+   TakeExtensionsBrowserClient();
+@@ -120,7 +120,7 @@ class StartupData {
+   std::unique_ptr<leveldb_proto::ProtoDatabaseProvider> proto_db_provider_;
+ #endif
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   std::unique_ptr<extensions::ExtensionsBrowserClient>
+       extensions_browser_client_;
+ #endif
+diff --git a/chrome/browser/task_manager/common/task_manager_features.cc b/chrome/browser/task_manager/common/task_manager_features.cc
+--- a/chrome/browser/task_manager/common/task_manager_features.cc
++++ b/chrome/browser/task_manager/common/task_manager_features.cc
+@@ -11,7 +11,7 @@ namespace features {
+ #if BUILDFLAG(IS_ANDROID)
+ // Enables the Task Manager on Clank.
+ BASE_FEATURE(kTaskManagerClank,
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+              base::FEATURE_ENABLED_BY_DEFAULT
+ #else
+              base::FEATURE_DISABLED_BY_DEFAULT
+diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -680,7 +680,7 @@ static_library("ui") {
+   }
+ 
+   # Desktop-Android-only dependencies.
+-  if (is_desktop_android) {
++  if (is_desktop_android_thorium) {
+     deps += [ "//chrome/browser/ui/android/extensions/windowing/internal" ]
+   }
+   if (is_android) {
+@@ -2924,7 +2924,7 @@ static_library("ui") {
+     allow_circular_includes_from += [ "//chrome/browser/ui/wallet" ]
+   }
+ 
+-  if (is_win || is_mac || is_linux || is_chromeos || is_desktop_android) {
++  if (is_win || is_mac || is_linux || is_chromeos || is_desktop_android_thorium) {
+     sources += [
+       "webui/discards/discards_ui.cc",
+       "webui/discards/discards_ui.h",
+diff --git a/chrome/browser/ui/android/context_menu_helper.cc b/chrome/browser/ui/android/context_menu_helper.cc
+--- a/chrome/browser/ui/android/context_menu_helper.cc
++++ b/chrome/browser/ui/android/context_menu_helper.cc
+@@ -24,7 +24,7 @@
+ #include "ui/gfx/geometry/size.h"
+ #include "url/gurl.h"
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ #include "chrome/browser/extensions/extension_menu_model_android.h"
+ #include "ui/menus/simple_menu_model.h"
+ #endif  // BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
+@@ -44,7 +44,7 @@ ContextMenuHelper::ContextMenuHelper(content::WebContents* web_contents)
+ }
+ 
+ ContextMenuHelper::~ContextMenuHelper() {
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   extension_menu_model_.reset();
+ #endif  // BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
+   JNIEnv* env = base::android::AttachCurrentThread();
+@@ -58,7 +58,7 @@ void ContextMenuHelper::ShowContextMenu(
+   context_menu_params_ = params;
+   gfx::NativeView view = GetWebContents().GetNativeView();
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   // Reset any previous menu model, in case a new menu is shown
+   // before the old one was gracefully closed.
+   extension_menu_model_.reset();
+@@ -81,11 +81,17 @@ void ContextMenuHelper::ShowContextMenu(
+ }
+ 
+ void ContextMenuHelper::DismissContextMenu() {
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
++  extension_menu_model_.reset();
++#endif  // BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
+   JNIEnv* env = base::android::AttachCurrentThread();
+   Java_ContextMenuHelper_dismissContextMenu(env, java_obj_);
+ }
+ 
+ void ContextMenuHelper::OnContextMenuClosed(JNIEnv* env) {
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
++  extension_menu_model_.reset();
++#endif  // BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
+   GetWebContents().NotifyContextMenuClosed(context_menu_params_.link_followed,
+                                            context_menu_params_.impression);
+ }
+diff --git a/chrome/browser/ui/android/context_menu_helper.h b/chrome/browser/ui/android/context_menu_helper.h
+--- a/chrome/browser/ui/android/context_menu_helper.h
++++ b/chrome/browser/ui/android/context_menu_helper.h
+@@ -14,7 +14,7 @@
+ #include "extensions/buildflags/buildflags.h"
+ #include "mojo/public/cpp/bindings/associated_remote.h"
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ namespace extensions {
+ class ExtensionMenuModel;
+ }
+@@ -53,7 +53,7 @@ class ContextMenuHelper
+ 
+   content::ContextMenuParams context_menu_params_;
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   std::unique_ptr<extensions::ExtensionMenuModel> extension_menu_model_;
+ #endif  // BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
+ 
+diff --git a/chrome/browser/ui/android/desktop_site/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteUtils.java b/chrome/browser/ui/android/desktop_site/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteUtils.java
+--- a/chrome/browser/ui/android/desktop_site/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteUtils.java
++++ b/chrome/browser/ui/android/desktop_site/java/src/org/chromium/chrome/browser/desktop_site/DesktopSiteUtils.java
+@@ -115,7 +115,7 @@ public class DesktopSiteUtils {
+      */
+     static boolean shouldDefaultEnableGlobalSetting(double displaySizeInInches, Context context) {
+         // Desktop Android always requests desktop sites.
+-        if (DeviceInfo.isDesktop()) {
++        if (DeviceInfo.isDesktopFalse()) {
+             return true;
+         }
+ 
+@@ -195,7 +195,7 @@ public class DesktopSiteUtils {
+         boolean isOnExternalDisplay = isOnExternalDisplay(activity);
+         if (isOnExternalDisplay
+                 || smallestScreenWidthDp < DeviceFormFactor.MINIMUM_TABLET_WIDTH_DP
+-                || DeviceInfo.isDesktop()) {
++                || DeviceInfo.isDesktopFalse()) {
+             return;
+         }
+         PrefService prefService = UserPrefs.get(profile);
+diff --git a/chrome/browser/ui/android/desktop_windowing/java/src/org/chromium/chrome/browser/ui/desktop_windowing/TopControlsLockCoordinator.java b/chrome/browser/ui/android/desktop_windowing/java/src/org/chromium/chrome/browser/ui/desktop_windowing/TopControlsLockCoordinator.java
+--- a/chrome/browser/ui/android/desktop_windowing/java/src/org/chromium/chrome/browser/ui/desktop_windowing/TopControlsLockCoordinator.java
++++ b/chrome/browser/ui/android/desktop_windowing/java/src/org/chromium/chrome/browser/ui/desktop_windowing/TopControlsLockCoordinator.java
+@@ -100,7 +100,7 @@ public class TopControlsLockCoordinator {
+     private boolean shouldLockTopControls() {
+         // Desktop form factor always take priority.
+         // TODO(crbug.com/450970998): Explore if we can set this for all large tablets.
+-        if (DeviceInfo.isDesktop()) return true;
++        if (DeviceInfo.isDesktopFalse()) return true;
+ 
+         // Enable lock in desktop window mode. Only relevant when the device supports it.
+         if (mDesktopWindowStateManager != null) {
+diff --git a/chrome/browser/ui/android/extensions/BUILD.gn b/chrome/browser/ui/android/extensions/BUILD.gn
+--- a/chrome/browser/ui/android/extensions/BUILD.gn
++++ b/chrome/browser/ui/android/extensions/BUILD.gn
+@@ -86,8 +86,8 @@ if (enable_extensions_core) {
+ # BuildConfig.
+ java_cpp_template("generate_buildflags") {
+   sources = [ "java/templates/ExtensionsBuildflags.template" ]
+-  if (enable_desktop_android_extensions) {
+-    defines = [ "_ENABLE_DESKTOP_ANDROID_EXTENSIONS" ]
++  if (enable_desktop_android_extensions_thorium) {
++    defines = [ "_ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE" ]
+   }
+ }
+ 
+diff --git a/chrome/browser/ui/android/extensions/extension_actions_bridge.cc b/chrome/browser/ui/android/extensions/extension_actions_bridge.cc
+--- a/chrome/browser/ui/android/extensions/extension_actions_bridge.cc
++++ b/chrome/browser/ui/android/extensions/extension_actions_bridge.cc
+@@ -8,11 +8,14 @@
+ #include <variant>
+ 
+ #include "base/android/jni_string.h"
++#include "base/files/file_util.h"
++#include "base/task/thread_pool.h"
+ #include "chrome/browser/extensions/extension_action_runner.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+ #include "chrome/browser/ui/extensions/icon_with_badge_image_source.h"
+ #include "content/public/browser/web_contents.h"
++#include "extensions/common/constants.h"
+ #include "extensions/browser/extension_action.h"
+ #include "extensions/browser/extension_action_manager.h"
+ #include "extensions/browser/extension_registry.h"
+@@ -198,6 +201,26 @@ ExtensionAction::ShowAction ExtensionActionsBridge::RunAction(
+   return runner->RunAction(extension, /*grant_tab_permissions=*/true);
+ }
+ 
++void ExtensionActionsBridge::ClearExtensionData(JNIEnv* env) {
++  auto install_directory = profile_->GetPath().AppendASCII(kInstallDirectoryName);
++  auto install_updacked_directory = profile_->GetPath().AppendASCII(kInstallDirectoryName);
++
++  base::ThreadPool::PostTask(
++        FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_BLOCKING},
++        base::BindOnce(
++            [](const base::FilePath& install_directory,
++               const base::FilePath& install_updacked_directory) {
++              LOG(INFO) << "Removing " << install_directory;
++              if (!base::DeletePathRecursively(install_directory))
++                LOG(ERROR) << "Failed";
++
++              LOG(INFO) << "Removing " << install_updacked_directory;
++              if (!base::DeletePathRecursively(install_updacked_directory))
++                LOG(ERROR) << "Failed";
++        },
++        install_directory, install_updacked_directory));
++}
++
+ jni_zero::ScopedJavaLocalRef<jobject>
+ ExtensionActionsBridge::HandleKeyDownEvent(
+     JNIEnv* env,
+diff --git a/chrome/browser/ui/android/extensions/extension_actions_bridge.h b/chrome/browser/ui/android/extensions/extension_actions_bridge.h
+--- a/chrome/browser/ui/android/extensions/extension_actions_bridge.h
++++ b/chrome/browser/ui/android/extensions/extension_actions_bridge.h
+@@ -52,6 +52,7 @@ class ExtensionActionsBridge : public ToolbarActionsModel::Observer {
+       const ToolbarActionsModel::ActionId& action_id,
+       int tab_id,
+       content::WebContents* web_contents);
++  void ClearExtensionData(JNIEnv* env);
+   jni_zero::ScopedJavaLocalRef<jobject> HandleKeyDownEvent(
+       JNIEnv* env,
+       const ui::KeyEventAndroid& key_event);
+diff --git a/chrome/browser/ui/android/extensions/extensions_toolbar_android.cc b/chrome/browser/ui/android/extensions/extensions_toolbar_android.cc
+--- a/chrome/browser/ui/android/extensions/extensions_toolbar_android.cc
++++ b/chrome/browser/ui/android/extensions/extensions_toolbar_android.cc
+@@ -152,6 +152,7 @@ base::android::ScopedJavaLocalRef<jobject> ExtensionsToolbarAndroid::GetAction(
+     const ToolbarActionsModel::ActionId& action_id) {
+   ToolbarActionViewModel* action =
+       toolbar_view_model_->GetActionModelForId(action_id);
++  if (!action) return nullptr;
+   return Java_ExtensionAction_Constructor(
+       env, action_id, base::UTF16ToUTF8(action->GetActionName()));
+ }
+diff --git a/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu.xml b/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu.xml
+--- a/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu.xml
++++ b/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu.xml
+@@ -65,6 +65,7 @@ found in the LICENSE file.
+ 
+     <View
+         android:id="@+id/extensions_menu_footer_divider"
++        android:visibility="gone"
+         android:layout_width="0dp"
+         android:layout_height="1dp"
+         app:layout_constraintTop_toBottomOf="@+id/extensions_menu_items"
+diff --git a/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu_footer.xml b/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu_footer.xml
+--- a/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu_footer.xml
++++ b/chrome/browser/ui/android/extensions/java/res/layout/extensions_menu_footer.xml
+@@ -13,6 +13,7 @@ found in the LICENSE file.
+ 
+     <androidx.appcompat.widget.AppCompatButton
+         android:id="@+id/extensions_menu_discover_extensions_button"
++        android:visibility="gone"
+         style="?android:attr/borderlessButtonStyle"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+@@ -29,6 +30,7 @@ found in the LICENSE file.
+ 
+     <androidx.appcompat.widget.AppCompatButton
+         android:id="@+id/extensions_menu_manage_extensions_button"
++        android:visibility="gone"
+         style="?android:attr/borderlessButtonStyle"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+@@ -43,4 +45,4 @@ found in the LICENSE file.
+         android:drawableTint="?android:attr/textColorPrimary"
+         android:gravity="start|center_vertical"/>
+ 
+-</LinearLayout>
+\ No newline at end of file
++</LinearLayout>
+diff --git a/chrome/browser/ui/android/extensions/java/res/values/dimens.xml b/chrome/browser/ui/android/extensions/java/res/values/dimens.xml
+--- a/chrome/browser/ui/android/extensions/java/res/values/dimens.xml
++++ b/chrome/browser/ui/android/extensions/java/res/values/dimens.xml
+@@ -13,4 +13,5 @@ found in the LICENSE file.
+         toolbar UI with the assumption that the UI is usable with the width.
+     -->
+     <dimen name="extension_toolbar_baseline_width">600dp</dimen>
++    <dimen name="extension_toolbar_baseline_min_width">50dp</dimen>
+ </resources>
+diff --git a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java
+--- a/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java
++++ b/chrome/browser/ui/android/extensions/java/src/org/chromium/chrome/browser/ui/extensions/ExtensionActionsBridge.java
+@@ -241,6 +241,10 @@ public class ExtensionActionsBridge implements Destroyable {
+         void onActionIconUpdated(String actionId);
+     }
+ 
++    public void clearExtensionData() {
++        ExtensionActionsBridgeJni.get().clearExtensionData(mNativeExtensionActionsBridge);
++    }
++
+     @NativeMethods
+     public interface Natives {
+         boolean extensionsEnabled(@JniType("Profile*") Profile profile);
+@@ -275,6 +279,8 @@ public class ExtensionActionsBridge implements Destroyable {
+                 int tabId,
+                 @JniType("content::WebContents*") WebContents webContents);
+ 
++        void clearExtensionData(long nativeExtensionActionsBridge);
++
+         HandleKeyEventResult handleKeyDownEvent(
+                 long nativeExtensionActionsBridge,
+                 @JniType("ui::KeyEventAndroid") KeyEvent keyEvent);
+diff --git a/chrome/browser/ui/android/extensions/windowing/internal/BUILD.gn b/chrome/browser/ui/android/extensions/windowing/internal/BUILD.gn
+--- a/chrome/browser/ui/android/extensions/windowing/internal/BUILD.gn
++++ b/chrome/browser/ui/android/extensions/windowing/internal/BUILD.gn
+@@ -6,7 +6,7 @@ import("//build/config/android/rules.gni")
+ import("//build/config/chrome_build.gni")
+ import("//third_party/jni_zero/jni_zero.gni")
+ 
+-assert(is_desktop_android)
++assert(is_desktop_android_thorium)
+ 
+ source_set("internal") {
+   sources = [
+diff --git a/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.cc b/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.cc
+--- a/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.cc
++++ b/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.cc
+@@ -69,12 +69,13 @@ ExtensionWindowControllerBridge::ExtensionWindowControllerBridge(
+         java_extension_window_controller_bridge,
+     BrowserWindowInterface* browser_window)
+     : extension_window_controller_(
+-          BrowserExtensionWindowController(browser_window)) {
++        std::make_unique<extensions::BrowserExtensionWindowController>(browser_window)) {
+   java_extension_window_controller_bridge_.Reset(
+       env, java_extension_window_controller_bridge);
+ }
+ 
+ ExtensionWindowControllerBridge::~ExtensionWindowControllerBridge() {
++  extension_window_controller_.reset();
+   Java_ExtensionWindowControllerBridgeImpl_clearNativePtr(
+       AttachCurrentThread(), java_extension_window_controller_bridge_);
+ }
+@@ -84,22 +85,22 @@ void ExtensionWindowControllerBridge::Destroy(JNIEnv* env) {
+ }
+ 
+ void ExtensionWindowControllerBridge::OnTaskBoundsChanged(JNIEnv* env) {
+-  extension_window_controller_.NotifyWindowBoundsChanged();
++  extension_window_controller_->NotifyWindowBoundsChanged();
+ }
+ 
+ void ExtensionWindowControllerBridge::OnTaskFocusChanged(JNIEnv* env,
+                                                          bool has_focus) {
+-  extension_window_controller_.NotifyWindowFocusChanged(has_focus);
++  extension_window_controller_->NotifyWindowFocusChanged(has_focus);
+ }
+ 
+ int ExtensionWindowControllerBridge::GetExtensionWindowIdForTesting(
+     JNIEnv* env) {
+-  return extension_window_controller_.GetWindowId();
++  return extension_window_controller_->GetWindowId();
+ }
+ 
+-const BrowserExtensionWindowController&
+-ExtensionWindowControllerBridge::GetExtensionWindowControllerForTesting() {
+-  return extension_window_controller_;
+-}
++// const BrowserExtensionWindowController&
++// ExtensionWindowControllerBridge::GetExtensionWindowControllerForTesting() {
++//   return extension_window_controller_;
++// }
+ 
+ DEFINE_JNI(ExtensionWindowControllerBridgeImpl)
+diff --git a/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.h b/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.h
+--- a/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.h
++++ b/chrome/browser/ui/android/extensions/windowing/internal/extension_window_controller_bridge.h
+@@ -64,7 +64,7 @@ class ExtensionWindowControllerBridge final {
+   base::android::ScopedJavaGlobalRef<jobject>
+       java_extension_window_controller_bridge_;
+ 
+-  extensions::BrowserExtensionWindowController extension_window_controller_;
++  std::unique_ptr<extensions::BrowserExtensionWindowController> extension_window_controller_;
+ 
+   raw_ptr<WindowControllerListObserverForTesting>
+       window_controller_list_observer_for_testing_;
+diff --git a/chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Enable-extensions-Android.grdp b/chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Enable-extensions-Android.grdp
+new file mode 100644
+--- /dev/null
++++ b/chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Enable-extensions-Android.grdp
+@@ -0,0 +1,15 @@
++<?xml version="1.0" encoding="utf-8"?>
++<grit-part>
++    <message name="IDS_STORAGE_MANAGEMENT_EXTENSION_STORAGE_DESCRIPTION" desc="Text used to describe extension storage space used by Chrome.">
++        Total data used by extensions
++    </message>
++    <message name="IDS_STORAGE_MANAGEMENT_CLEAR_ALL_EXTENSION_BUTTON" desc="Text on the button to clear all extension data. [CHAR_LIMIT=30]">
++        Clear All Extensions Data
++    </message>
++    <message name="IDS_STORAGE_MANAGEMENT_EXTENSION_RESET_APP_DIALOG_TITLE" desc="Title of the reset extension dialog in the storage UI used to reset the app.">
++        Delete extension data?
++    </message>
++    <message name="IDS_STORAGE_MANAGEMENT_EXTENSION_RESET_APP_DIALOG_TEXT" desc="Text of the reset extension dialoag in the storage UI.">
++        All Chrome’s extension data will be deleted permanently.
++    </message>
++</grit-part>
+diff --git a/chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Extensions-Android.grdp b/chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Extensions-Android.grdp
+new file mode 100644
+--- /dev/null
++++ b/chrome/browser/ui/android/strings/thorium_android_chrome_strings_grd/Extensions-Android.grdp
+@@ -0,0 +1,9 @@
++<?xml version="1.0" encoding="utf-8"?>
++<grit-part>
++    <message name="IDS_ANDROID_EXTENSIONS_TITLE" desc="">
++        Enable Extensions
++    </message>
++    <message name="IDS_ANDROID_EXTENSIONS_SUMMARY" desc="">
++        Enable experimental support for extensions in Android
++    </message>
++</grit-part>
+diff --git a/chrome/browser/ui/android/tab_model/tab_model.cc b/chrome/browser/ui/android/tab_model/tab_model.cc
+--- a/chrome/browser/ui/android/tab_model/tab_model.cc
++++ b/chrome/browser/ui/android/tab_model/tab_model.cc
+@@ -47,7 +47,7 @@ sync_sessions::OpenTabsUIDelegate* GetOpenTabsUIDelegate(Profile* profile) {
+ // TODO(http://crbug.com/444518651): remove the if-def when
+ // |BrowserWindowInterface| is compiled and running on all Android builds.
+ SessionID GetInitialSessionId() {
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   return SessionID::InvalidValue();
+ #else
+   return SessionID::NewUnique();
+@@ -157,7 +157,7 @@ void TabModel::RecordActualSyncedTabsHistogram() {
+ 
+ // TODO(http://crbug.com/444518651): remove the if-def when
+ // |BrowserWindowInterface| is compiled and running on all Android builds.
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ void TabModel::SetSessionId(SessionID session_id) {
+   session_id_ = session_id;
+ }
+diff --git a/chrome/browser/ui/android/tab_model/tab_model.h b/chrome/browser/ui/android/tab_model/tab_model.h
+--- a/chrome/browser/ui/android/tab_model/tab_model.h
++++ b/chrome/browser/ui/android/tab_model/tab_model.h
+@@ -320,7 +320,7 @@ class TabModel : public TabListInterface {
+ 
+   LocationBarModel* GetLocationBarModel();
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   // Sets the |SessionID|.
+   //
+   // This is only needed on desktop Android, where |BrowserWindowInterface|
+diff --git a/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc b/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc
+--- a/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc
++++ b/chrome/browser/ui/android/tab_model/tab_model_jni_bridge.cc
+@@ -51,7 +51,7 @@
+ 
+ // "chrome/browser/ui/browser_window" is available on desktop Android, but not
+ // other Android builds.
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ #include "chrome/browser/ui/browser_window/internal/android/android_browser_window.h"  // nogncheck
+ #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"  // nogncheck
+ #include "chrome/browser/ui/browser_window/public/browser_window_interface_iterator.h"  // nogncheck
+@@ -91,7 +91,7 @@ std::vector<TabAndroid*> GetAllTabsFromHandles(const Container& handles) {
+   return tabs;
+ }
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ AndroidBrowserWindow* GetAndroidBrowserWindow(SessionID session_id) {
+   for (BrowserWindowInterface* window : GetAllBrowserWindowInterfaces()) {
+     if (window->GetSessionID() == session_id) {
+@@ -129,7 +129,7 @@ void TabModelJniBridge::AssociateWithBrowserWindow(
+     long native_android_browser_window) {
+ // BrowserWindowInterface is available on desktop Android, but not other Android
+ // builds. For non-desktop Android, this function should be a no-op.
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   BrowserWindowInterface* android_browser_window =
+       reinterpret_cast<BrowserWindowInterface*>(native_android_browser_window);
+   CHECK(android_browser_window != nullptr);
+@@ -165,7 +165,7 @@ void TabModelJniBridge::MoveTabToWindowForTesting(
+     TabAndroid* tab,
+     long android_browser_window_ptr,
+     int new_index) {
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   SessionID destination_window_id =
+       reinterpret_cast<AndroidBrowserWindow*>(android_browser_window_ptr)
+           ->GetSessionID();
+@@ -180,7 +180,7 @@ void TabModelJniBridge::MoveTabGroupToWindowForTesting(
+     const base::Token& group_id,
+     long android_browser_window_ptr,
+     int new_index) {
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   SessionID destination_window_id =
+       reinterpret_cast<AndroidBrowserWindow*>(android_browser_window_ptr)
+           ->GetSessionID();
+@@ -804,7 +804,7 @@ void TabModelJniBridge::MoveTabGroupToWindow(tab_groups::TabGroupId group_id,
+ ScopedJavaLocalRef<jobject> TabModelJniBridge::GetActivityForWindow(
+     SessionID window_id) {
+   ScopedJavaLocalRef<jobject> jactivity;
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   AndroidBrowserWindow* window = GetAndroidBrowserWindow(window_id);
+   if (!window) {
+     return jactivity;
+diff --git a/chrome/browser/ui/android/tab_model/tab_model_test_helper.h b/chrome/browser/ui/android/tab_model/tab_model_test_helper.h
+--- a/chrome/browser/ui/android/tab_model/tab_model_test_helper.h
++++ b/chrome/browser/ui/android/tab_model/tab_model_test_helper.h
+@@ -124,7 +124,7 @@ class TestTabModel : public TabModel {
+ 
+ // BrowserWindowInterface is available on desktop Android, but not other Android
+ // builds.
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   void AssociateWithBrowserWindow(BrowserWindowInterface* browser_window);
+ #endif
+ 
+diff --git a/chrome/browser/ui/android/toolbar/java/res/layout/toolbar_phone.xml b/chrome/browser/ui/android/toolbar/java/res/layout/toolbar_phone.xml
+--- a/chrome/browser/ui/android/toolbar/java/res/layout/toolbar_phone.xml
++++ b/chrome/browser/ui/android/toolbar/java/res/layout/toolbar_phone.xml
+@@ -65,6 +65,12 @@ found in the LICENSE file.
+             android:layout_width="52dp"
+             style="@style/ToolbarHoverableButton"/>
+ 
++        <ViewStub
++            android:id="@+id/extension_toolbar_container_stub"
++            android:inflatedId="@+id/extension_toolbar_container"
++            android:layout_width="56dp"
++            android:layout_height="match_parent" />
++
+         <org.chromium.chrome.browser.toolbar.top.ToggleTabStackButton
+             android:id="@+id/tab_switcher_button"
+             style="@style/ToolbarHoverableButton"
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListRecyclerView.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListRecyclerView.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListRecyclerView.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionActionListRecyclerView.java
+@@ -37,7 +37,7 @@ public class ExtensionActionListRecyclerView extends RecyclerView {
+     @Override
+     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+         // The parent passes the window width as the maximum width.
+-        assert MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.AT_MOST;
++        // assert MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.AT_MOST;
+ 
+         int windowWidth = MeasureSpec.getSize(widthMeasureSpec);
+         int reservedWidth =
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionToolbarCoordinatorImpl.java
+@@ -6,6 +6,7 @@ package org.chromium.chrome.browser.toolbar.extensions;
+ 
+ import android.content.Context;
+ import android.view.KeyEvent;
++import android.view.View;
+ import android.view.ViewStub;
+ import android.widget.LinearLayout;
+ 
+@@ -21,6 +22,7 @@ import org.chromium.chrome.browser.theme.ThemeColorProvider;
+ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+ import org.chromium.chrome.browser.ui.extensions.ExtensionActionsBridge;
+ import org.chromium.chrome.browser.ui.extensions.ExtensionsToolbarBridge;
++import org.chromium.chrome.browser.ui.extensions.ExtensionUi;
+ import org.chromium.chrome.browser.ui.extensions.R;
+ import org.chromium.ui.base.WindowAndroid;
+ 
+@@ -55,6 +57,12 @@ public class ExtensionToolbarCoordinatorImpl implements ExtensionToolbarCoordina
+ 
+         mExtensionsToolbarBridge = new ExtensionsToolbarBridge(task, profile);
+ 
++        mProfileSupplier.addObserver((profile) -> {
++            if (!ExtensionUi.isEnabled(profileSupplier.get())) {
++                container.setVisibility(View.GONE);
++            }
++        });
++
+         mExtensionActionListCoordinator =
+                 new ExtensionActionListCoordinator(
+                         context,
+@@ -74,7 +82,8 @@ public class ExtensionToolbarCoordinatorImpl implements ExtensionToolbarCoordina
+                         currentTabSupplier,
+                         tabCreator,
+                         mExtensionsToolbarBridge,
+-                        container.findViewById(R.id.extensions_request_access_button));
++                        container.findViewById(R.id.extensions_request_access_button),
++                        mExtensionActionListCoordinator);
+     }
+ 
+     @Override
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuCoordinator.java
+@@ -25,6 +25,7 @@ import org.chromium.chrome.browser.tabmodel.TabCreator;
+ import org.chromium.chrome.browser.theme.ThemeColorProvider;
+ import org.chromium.chrome.browser.toolbar.MenuBuilderHelper;
+ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
++import org.chromium.chrome.browser.toolbar.extensions.ExtensionActionListCoordinator;
+ import org.chromium.chrome.browser.ui.extensions.R;
+ import org.chromium.chrome.browser.ui.theme.BrandedColorScheme;
+ import org.chromium.components.embedder_support.util.UrlConstants;
+@@ -61,6 +62,7 @@ public class ExtensionsMenuCoordinator implements Destroyable {
+     private final ChromeAndroidTask mTask;
+ 
+     private final ThemeColorProvider.TintObserver mTintObserver = this::onTintChanged;
++    private final ExtensionActionListCoordinator mExtensionActionListCoordinator;
+ 
+     @Nullable @VisibleForTesting ExtensionsMenuMediator mMediator;
+ 
+@@ -81,7 +83,9 @@ public class ExtensionsMenuCoordinator implements Destroyable {
+             ChromeAndroidTask task,
+             Profile profile,
+             NullableObservableSupplier<Tab> currentTabSupplier,
+-            TabCreator tabCreator) {
++            TabCreator tabCreator,
++            ExtensionActionListCoordinator extensionActionListCoordinator) {
++        mExtensionActionListCoordinator = extensionActionListCoordinator;
+         mContext = context;
+         mCurrentTabSupplier = currentTabSupplier;
+         mProfile = profile;
+@@ -179,7 +183,7 @@ public class ExtensionsMenuCoordinator implements Destroyable {
+                         mExtensionsMenuButton.getRootView(),
+                         /* onReady= */ () -> {
+                             mExtensionsMenuButton.showMenu();
+-                        });
++                        }, mExtensionActionListCoordinator);
+     }
+ 
+     /**
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemProperties.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemProperties.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemProperties.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemProperties.java
+@@ -18,8 +18,11 @@ public class ExtensionsMenuItemProperties {
+ 
+     public static final WritableObjectPropertyKey<String> TITLE = new WritableObjectPropertyKey<>();
+ 
++    public static final WritableObjectPropertyKey<View.OnClickListener> ITEM_CLICK_LISTENER =
++            new WritableObjectPropertyKey<>();
++
+     public static final WritableObjectPropertyKey<View.OnClickListener> CLICK_LISTENER =
+             new WritableObjectPropertyKey<>();
+ 
+-    public static final PropertyKey[] ALL_KEYS = new PropertyKey[] {ICON, TITLE, CLICK_LISTENER};
++    public static final PropertyKey[] ALL_KEYS = new PropertyKey[] {ICON, TITLE, ITEM_CLICK_LISTENER, CLICK_LISTENER};
+ }
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemViewBinder.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemViewBinder.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemViewBinder.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuItemViewBinder.java
+@@ -30,6 +30,8 @@ public class ExtensionsMenuItemViewBinder {
+             // TODO: Investigate the correct resizing method.
+             bitmap.setDensity(120);
+             iconView.setImageBitmap(bitmap);
++        } else if (key == ExtensionsMenuItemProperties.ITEM_CLICK_LISTENER) {
++            view.setOnClickListener(model.get(ExtensionsMenuItemProperties.ITEM_CLICK_LISTENER));
+         } else if (key == ExtensionsMenuItemProperties.CLICK_LISTENER) {
+             view.findViewById(R.id.extensions_menu_item_context_menu)
+                     .setOnClickListener(model.get(ExtensionsMenuItemProperties.CLICK_LISTENER));
+diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java
+--- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java
++++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/extensions/ExtensionsMenuMediator.java
+@@ -14,6 +14,7 @@ import org.chromium.build.annotations.NullMarked;
+ import org.chromium.chrome.browser.extensions.ContextMenuSource;
+ import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.tab.Tab;
++import org.chromium.chrome.browser.toolbar.extensions.ExtensionActionListCoordinator;
+ import org.chromium.chrome.browser.ui.browser_window.ChromeAndroidTask;
+ import org.chromium.chrome.browser.ui.extensions.ExtensionActionContextMenuBridge;
+ import org.chromium.chrome.browser.ui.extensions.ExtensionsMenuBridge;
+@@ -39,6 +40,7 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+     private final ChromeAndroidTask mTask;
+     private final Profile mProfile;
+     private final View mRootView;
++    private final ExtensionActionListCoordinator mExtensionActionListCoordinator;
+ 
+     /**
+      * @param context The context to use.
+@@ -56,7 +58,9 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+             ModelList actionModels,
+             PropertyModel propertyModel,
+             View rootView,
+-            Runnable onReady) {
++            Runnable onReady,
++            ExtensionActionListCoordinator extensionActionListCoordinator) {
++        mExtensionActionListCoordinator = extensionActionListCoordinator;
+         mActionModels = actionModels;
+         mContext = context;
+         mCurrentTabSupplier = currentTabSupplier;
+@@ -158,6 +162,9 @@ class ExtensionsMenuMediator implements Destroyable, ExtensionsMenuBridge.Observ
+             PropertyModel model =
+                     new PropertyModel.Builder(ExtensionsMenuItemProperties.ALL_KEYS)
+                             .with(ExtensionsMenuItemProperties.TITLE, name)
++                            .with(
++                                    ExtensionsMenuItemProperties.ITEM_CLICK_LISTENER,
++                                    (view) -> mExtensionActionListCoordinator.click(actionId))
+                             .with(
+                                     ExtensionsMenuItemProperties.CLICK_LISTENER,
+                                     (view) -> onContextMenuButtonClicked((ListMenuButton) view, id))
+diff --git a/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskTrackerFactory.java b/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskTrackerFactory.java
+--- a/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskTrackerFactory.java
++++ b/chrome/browser/ui/browser_window/internal/android/java/src/org/chromium/chrome/browser/ui/browser_window/ChromeAndroidTaskTrackerFactory.java
+@@ -19,10 +19,6 @@ public final class ChromeAndroidTaskTrackerFactory {
+      */
+     @Nullable
+     public static ChromeAndroidTaskTracker getInstance() {
+-        // TODO(crbug.com/473636857): Remove once this is properly implemented on non-desktop
+-        // platforms.
+-        if (!BuildConfig.IS_DESKTOP_ANDROID) return null;
+-
+         return ChromeAndroidTaskTrackerImpl.getInstance();
+     }
+ }
+diff --git a/chrome/browser/ui/prefs/BUILD.gn b/chrome/browser/ui/prefs/BUILD.gn
+--- a/chrome/browser/ui/prefs/BUILD.gn
++++ b/chrome/browser/ui/prefs/BUILD.gn
+@@ -65,7 +65,7 @@ source_set("impl") {
+   }
+ }
+ 
+-if (!is_android || enable_desktop_android_extensions) {
++if (!is_android || enable_desktop_android_extensions_thorium) {
+   source_set("browser_tests") {
+     testonly = true
+     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+@@ -83,7 +83,7 @@ if (!is_android || enable_desktop_android_extensions) {
+       "//third_party/blink/public/common:headers",
+     ]
+ 
+-    if (enable_desktop_android_extensions) {
++    if (enable_desktop_android_extensions_thorium) {
+       deps += [ "//chrome/test:test_support_ui_android" ]
+     } else {
+       deps += [ "//chrome/test:test_support_ui" ]
+diff --git a/chrome/browser/ui/prefs/prefs_tab_helper.cc b/chrome/browser/ui/prefs/prefs_tab_helper.cc
+--- a/chrome/browser/ui/prefs/prefs_tab_helper.cc
++++ b/chrome/browser/ui/prefs/prefs_tab_helper.cc
+@@ -78,7 +78,7 @@ using content::WebContents;
+ 
+ namespace {
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ // Registers a preference under the path |pref_name| for each script used for
+ // per-script font prefs.
+ // For example, for WEBKIT_WEBPREFS_FONTS_SERIF ("fonts.serif"):
+@@ -151,7 +151,7 @@ constexpr auto kFontDefaults = std::to_array<FontDefault>({
+     {prefs::kWebKitFantasyFontFamily, IDS_FANTASY_FONT_FAMILY},
+     {prefs::kWebKitMathFontFamily, IDS_MATH_FONT_FAMILY},
+ #if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN) || \
+-    BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++    BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+     {prefs::kWebKitStandardFontFamilyJapanese,
+      IDS_STANDARD_FONT_FAMILY_JAPANESE},
+     {prefs::kWebKitFixedFontFamilyJapanese, IDS_FIXED_FONT_FAMILY_JAPANESE},
+@@ -290,7 +290,7 @@ void OverrideFontFamily(blink::web_pref::WebPreferences* prefs,
+   (*map)[script] = base::UTF8ToUTF16(pref_value);
+ }
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ void RegisterLocalizedFontPref(user_prefs::PrefRegistrySyncable* registry,
+                                const char* path,
+                                int default_message_id) {
+@@ -451,7 +451,7 @@ void PrefsTabHelper::RegisterProfilePrefs(
+   }
+ 
+ // Register font prefs.  This is only configurable on desktop Chrome.
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   RegisterFontFamilyPrefs(registry, fonts_with_defaults);
+ 
+   registry->RegisterIntegerPref(prefs::kWebKitDefaultFontSize, 16);
+diff --git a/chrome/browser/ui/webui/chrome_web_ui_configs.cc b/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+--- a/chrome/browser/ui/webui/chrome_web_ui_configs.cc
++++ b/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+@@ -181,7 +181,7 @@
+         // BUILDFLAG(IS_ANDROID)
+ 
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
++    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ #include "chrome/browser/ui/webui/discards/discards_ui.h"
+ #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) ||
+         // BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
+@@ -422,7 +422,7 @@ void RegisterChromeWebUIConfigs() {
+         // BUILDFLAG(IS_ANDROID)
+ 
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
++    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   map.AddWebUIConfig(std::make_unique<DiscardsUIConfig>());
+ #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) ||
+         // BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
+diff --git a/chrome/browser/ui/webui/current_channel_logo.cc b/chrome/browser/ui/webui/current_channel_logo.cc
+--- a/chrome/browser/ui/webui/current_channel_logo.cc
++++ b/chrome/browser/ui/webui/current_channel_logo.cc
+@@ -28,8 +28,7 @@ int CurrentChannelLogoResourceId() {
+     case version_info::Channel::DEV:
+     case version_info::Channel::BETA:
+     case version_info::Channel::STABLE:
+-      CHECK_IS_TEST();
+-      [[fallthrough]];
++      return IDR_PRODUCT_LOGO_32;
+ #endif
+     case version_info::Channel::UNKNOWN:
+       return IDR_PRODUCT_LOGO_32;
+diff --git a/chrome/browser/ui/webui/discards/discards_ui.cc b/chrome/browser/ui/webui/discards/discards_ui.cc
+--- a/chrome/browser/ui/webui/discards/discards_ui.cc
++++ b/chrome/browser/ui/webui/discards/discards_ui.cc
+@@ -60,7 +60,7 @@
+ #include "url/gurl.h"
+ #include "url/origin.h"
+ 
+-#if !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if !BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ #include "chrome/browser/resource_coordinator/lifecycle_unit.h"
+ #include "chrome/browser/resource_coordinator/lifecycle_unit_state.mojom.h"
+ #include "chrome/browser/resource_coordinator/tab_lifecycle_unit.h"
+@@ -240,7 +240,7 @@ class DiscardsDetailsProviderImpl
+       info->site_engagement_score = GetSiteEngagementScore(contents);
+       info->has_focus = page_node->IsFocused();
+ 
+-#if !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if !BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+       auto* lifecycle_unit_external = resource_coordinator::
+           TabLifecycleUnitSource::GetTabLifecycleUnitExternal(contents);
+       // A TabLifecycleUnitExternal object is always a TabLifecycleUnit object.
+@@ -353,7 +353,7 @@ class DiscardsDetailsProviderImpl
+   }
+ 
+   void RefreshPerformanceTabCpuMeasurements() override {
+-#if !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if !BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+     performance_manager::user_tuning::PerformanceDetectionManager::GetInstance()
+         ->ForceTabCpuDataRefresh();
+ #endif  // !BUILDFLAG(IS_DESKTOP_ANDROID)
+@@ -375,7 +375,7 @@ DiscardsUI::DiscardsUI(content::WebUI* web_ui)
+       profile, chrome::kChromeUIDiscardsHost);
+ 
+   bool demoModeEnabled = false;
+-#if !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if !BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   demoModeEnabled = base::FeatureList::IsEnabled(
+       performance_manager::features::kPerformanceInterventionDemoMode);
+ #endif  // !BUILDFLAG(IS_DESKTOP_ANDROID)
+diff --git a/chrome/chrome_paks.gni b/chrome/chrome_paks.gni
+--- a/chrome/chrome_paks.gni
++++ b/chrome/chrome_paks.gni
+@@ -516,7 +516,7 @@ template("chrome_extra_paks") {
+       deps += [ "//chrome/browser/resources/app_settings:resources" ]
+     }
+ 
+-    if (is_win || is_mac || is_linux || is_chromeos || is_desktop_android) {
++    if (is_win || is_mac || is_linux || is_chromeos || is_desktop_android_thorium) {
+       sources += [ "$root_gen_dir/chrome/discards_resources.pak" ]
+       deps += [ "//chrome/browser/resources/discards:resources" ]
+     }
+diff --git a/chrome/common/chrome_switches.cc b/chrome/common/chrome_switches.cc
+--- a/chrome/common/chrome_switches.cc
++++ b/chrome/common/chrome_switches.cc
+@@ -809,7 +809,7 @@ const char kMarketUrlForTesting[] = "market-url-for-testing";
+ const char kRequestDesktopSites[] = "request-desktop-sites";
+ #endif  // BUILDFLAG(IS_ANDROID)
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ // If enabled, overrides the target playout delay for a casting mirroring
+ // session. The value will be parsed as milliseconds. Lowering this value will
+ // result in a lower end to end latency, but could come at the cost of other
+diff --git a/chrome/common/chrome_switches.h b/chrome/common/chrome_switches.h
+--- a/chrome/common/chrome_switches.h
++++ b/chrome/common/chrome_switches.h
+@@ -240,7 +240,7 @@ extern const char kMarketUrlForTesting[];
+ extern const char kRequestDesktopSites[];
+ #endif  // BUILDFLAG(IS_ANDROID)
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ extern const char kCastMirroringTargetPlayoutDelay[];
+ #endif
+ 
+diff --git a/chrome/common/extensions/api/api_sources.gni b/chrome/common/extensions/api/api_sources.gni
+--- a/chrome/common/extensions/api/api_sources.gni
++++ b/chrome/common/extensions/api/api_sources.gni
+@@ -73,6 +73,13 @@ uncompiled_sources_ = [
+   "top_sites.json",
+ ]
+ 
++if (enable_extensions_core && is_android) {
++  uncompiled_sources_ += [
++    "browser_action.json",
++    "page_action.json",
++  ]
++}
++
+ # Some APIs rely on types and headers from other APIs.
+ types_only_schema_sources_ = []
+ 
+diff --git a/chrome/common/webui_url_constants.cc b/chrome/common/webui_url_constants.cc
+--- a/chrome/common/webui_url_constants.cc
++++ b/chrome/common/webui_url_constants.cc
+@@ -208,7 +208,7 @@ base::span<const base::cstring_view> ChromeURLHosts() {
+       kChromeUIInternetDetailDialogHost,
+ #endif
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
++    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+       kChromeUIDiscardsHost,
+ #endif
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+diff --git a/chrome/common/webui_url_constants.h b/chrome/common/webui_url_constants.h
+--- a/chrome/common/webui_url_constants.h
++++ b/chrome/common/webui_url_constants.h
+@@ -566,7 +566,7 @@ inline constexpr char kChromeUIOsUrlAppURL[] = "chrome://internal/";
+ #endif  // BUILDFLAG(IS_CHROMEOS)
+ 
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID)
++    BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ inline constexpr char kChromeUIDiscardsHost[] = "discards";
+ inline constexpr char kChromeUIDiscardsURL[] = "chrome://discards/";
+ #endif
+diff --git a/chrome/renderer/sandbox_status_extension_android.cc b/chrome/renderer/sandbox_status_extension_android.cc
+--- a/chrome/renderer/sandbox_status_extension_android.cc
++++ b/chrome/renderer/sandbox_status_extension_android.cc
+@@ -34,7 +34,7 @@ SandboxStatusExtension::SandboxStatusExtension(content::RenderFrame* frame)
+   frame->GetAssociatedInterfaceRegistry()
+       ->AddInterface<chrome::mojom::SandboxStatusExtension>(base::BindRepeating(
+           &SandboxStatusExtension::OnSandboxStatusExtensionRequest,
+-          base::RetainedRef(this)));
++          weak_ptr_factory_.GetWeakPtr()));
+ }
+ 
+ SandboxStatusExtension::~SandboxStatusExtension() = default;
+@@ -46,6 +46,7 @@ void SandboxStatusExtension::Create(content::RenderFrame* frame) {
+ }
+ 
+ void SandboxStatusExtension::OnDestruct() {
++  weak_ptr_factory_.InvalidateWeakPtrs();
+   // This object is ref-counted, since a callback could still be in-flight.
+   Release();
+ }
+diff --git a/chrome/renderer/sandbox_status_extension_android.h b/chrome/renderer/sandbox_status_extension_android.h
+--- a/chrome/renderer/sandbox_status_extension_android.h
++++ b/chrome/renderer/sandbox_status_extension_android.h
+@@ -73,6 +73,7 @@ class SandboxStatusExtension
+ 
+   mojo::AssociatedReceiver<chrome::mojom::SandboxStatusExtension> receiver_{
+       this};
++  base::WeakPtrFactory<SandboxStatusExtension> weak_ptr_factory_{this};
+ };
+ 
+ #endif  // CHROME_RENDERER_SANDBOX_STATUS_EXTENSION_ANDROID_H_
+diff --git a/chrome/test/BUILD.gn b/chrome/test/BUILD.gn
+--- a/chrome/test/BUILD.gn
++++ b/chrome/test/BUILD.gn
+@@ -371,7 +371,7 @@ static_library("test_support") {
+     ]
+   }
+ 
+-  if (enable_desktop_android_extensions) {
++  if (enable_desktop_android_extensions_thorium) {
+     public_deps += [
+       "//extensions/browser:test_support",
+       "//extensions/common:test_support",
+@@ -483,7 +483,7 @@ static_library("test_support") {
+   # TODO(https://crbug.com/356905053): Continue pulling more common test
+   # support pieces into here and eventually merge this with the
+   # `enable_extensions` block above.
+-  if (enable_desktop_android_extensions) {
++  if (enable_desktop_android_extensions_thorium) {
+     deps += [ "//chrome/renderer/extensions" ]
+ 
+     public_deps += [
+@@ -1563,7 +1563,7 @@ source_set("platform_browser_tests") {
+     sources += [ "../browser/enterprise/remote_commands/user_remote_commands_service_browsertest.cc" ]
+   }
+ 
+-  if (!is_android || enable_desktop_android_extensions) {
++  if (!is_android || enable_desktop_android_extensions_thorium) {
+     deps += [ "//chrome/browser/ui/prefs:browser_tests" ]
+   }
+ 
+@@ -1854,7 +1854,7 @@ source_set("platform_browser_tests") {
+     if (enable_guest_view) {
+       deps += [ "//components/guest_view/browser" ]
+     }
+-    if (!is_android || enable_desktop_android_extensions) {
++    if (!is_android || enable_desktop_android_extensions_thorium) {
+       sources +=
+           [ "../browser/devtools/global_confirm_info_bar_browsertest.cc" ]
+     }
+@@ -2153,7 +2153,7 @@ if (is_android) {
+     extra_args = []
+ 
+     # TODO(crbug.com/473636857): Include once all Android builds correctly use BrowserWindowInterface.
+-    if (is_desktop_android) {
++    if (is_desktop_android_thorium) {
+       sources +=
+           [ "../browser/ui/android/browser_navigator_android_browsertest.cc" ]
+       deps += [
+@@ -2249,7 +2249,7 @@ if (is_android) {
+       ]
+     }
+ 
+-    if (enable_desktop_android_extensions) {
++    if (enable_desktop_android_extensions_thorium) {
+       sources += [
+         # These API tests can't be part of platform_browser_tests because they
+         # run in interactive_ui_tests on Win/Mac/Linux.
+@@ -6333,7 +6333,7 @@ template("performance_test_suite_template_base") {
+     }
+     args += [ "--chromium-output-directory=@WrappedPath(.)" ]
+ 
+-    if (is_desktop_android) {
++    if (is_desktop_android_thorium) {
+       data = [ "//third_party/crossbench-web-tests" ]
+     }
+ 
+@@ -8187,7 +8187,7 @@ test("unit_tests") {
+       deps += [ "//chrome/browser/android/extensions:android" ]
+     }
+ 
+-    if (is_desktop_android) {
++    if (is_desktop_android_thorium) {
+       deps += [
+         # Unit test targets for //chrome/browser/ui/browser_window/internal.
+         #
+@@ -10039,7 +10039,7 @@ test("unit_tests") {
+     ]
+   }
+ 
+-  if (!is_android || enable_desktop_android_extensions) {
++  if (!is_android || enable_desktop_android_extensions_thorium) {
+     sources +=
+         [ "../browser/policy/developer_tools_policy_handler_unittest.cc" ]
+   }
+diff --git a/chrome/version.gni b/chrome/version.gni
+--- a/chrome/version.gni
++++ b/chrome/version.gni
+@@ -56,7 +56,7 @@ if (target_os == "android") {
+   # Generate hybrid configurations for target_cpu's that can run in hybrid configurations.
+   # i.e. "riscv64" does not show up in this list, as it's a 64-bit-only target_cpu.
+   if (target_cpu == "arm64" || target_cpu == "x64") {
+-    if (is_desktop_android) {
++    if (is_desktop_android_false_thorium) {
+       _version_dictionary_template +=
+           "chrome_desktop_version_code = \"@CHROME_DESKTOP_VERSION_CODE@\" "
+       _version_dictionary_template += "chrome_desktop_beta_version_code = \"@CHROME_DESKTOP_BETA_VERSION_CODE@\" "
+@@ -384,7 +384,7 @@ if (is_android) {
+           } else {
+             true_true_true_true = trichrome_64_32_version_code
+           }
+-          if (is_desktop_android) {
++          if (is_desktop_android_false_thorium) {
+             true_true_true_false = trichrome_desktop_64_version_code
+           } else {
+             true_true_true_false = trichrome_64_version_code
+diff --git a/components/content_settings/core/browser/host_content_settings_map.cc b/components/content_settings/core/browser/host_content_settings_map.cc
+--- a/components/content_settings/core/browser/host_content_settings_map.cc
++++ b/components/content_settings/core/browser/host_content_settings_map.cc
+@@ -327,6 +327,12 @@ HostContentSettingsMap::HostContentSettingsMap(PrefService* prefs,
+     RecordExceptionMetrics();
+   }
+ 
++#if BUILDFLAG(IS_ANDROID)
++  SetContentSettingDefaultScope(
++    GURL("https://chromewebstore.google.com"), GURL(),
++    ContentSettingsType::REQUEST_DESKTOP_SITE, CONTENT_SETTING_ALLOW);
++#endif
++
+   const auto* registry =
+       content_settings::WebsiteSettingsRegistry::GetInstance();
+   for (const auto* info : *registry) {
+diff --git a/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java b/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java
+--- a/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java
++++ b/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java
+@@ -449,7 +449,7 @@ public class ContentView extends FrameLayout
+         }
+         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+                 && Build.VERSION.SDK_INT <= 38
+-                && DeviceInfo.isDesktop()) {
++                && DeviceInfo.isDesktopFalse()) {
+             if (MotionEventUtils.isTrackpadEvent(event)
+                     && event.getClassification() == MotionEvent.CLASSIFICATION_TWO_FINGER_SWIPE
+                     && forwarder != null) {
+diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
+--- a/components/embedder_support/user_agent_utils.cc
++++ b/components/embedder_support/user_agent_utils.cc
+@@ -304,7 +304,7 @@ std::string GetUnifiedPlatform() {
+ #if BUILDFLAG(IS_ANDROID)
+   // The Android XR device by default also has the unified platform of desktop
+   // form factor.
+-  if (base::android::device_info::is_desktop() ||
++  if (base::android::device_info::is_desktop_false() ||
+       base::android::device_info::is_xr()) {
+     return kUnifiedPlatformLinuxX64;
+   }
+@@ -563,7 +563,7 @@ bool GetMobileBitForUAMetadata() {
+   // Android and not a desktop form factor, AND the kUseMobileUserAgent switch
+   // is present.
+ #if BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop() ||
++  if (base::android::device_info::is_desktop_false() ||
+       base::android::device_info::is_xr()) {
+     return false;
+   }
+@@ -586,7 +586,7 @@ std::string GetPlatformVersion() {
+ #endif
+ 
+ #if BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop() ||
++  if (base::android::device_info::is_desktop_false() ||
+       base::android::device_info::is_xr()) {
+     return std::string();
+   }
+@@ -606,7 +606,7 @@ std::string GetPlatformVersion() {
+ 
+ std::string GetPlatformForUAMetadata() {
+ #if BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop() ||
++  if (base::android::device_info::is_desktop_false() ||
+       base::android::device_info::is_xr()) {
+     return base::FeatureList::IsEnabled(
+                blink::features::kAndroidDesktopUAPlatform)
+@@ -729,7 +729,7 @@ std::string GetCpuArchitecture() {
+   // TODO(crbug.com/433345971) The user agent string should contain the actual
+   // cpu type information obtained from the Android device. Same for the cpu bit
+   // count in #GetCpuBitness below.
+-  if (base::android::device_info::is_desktop() ||
++  if (base::android::device_info::is_desktop_false() ||
+       base::android::device_info::is_xr()) {
+     return "x86";
+   }
+@@ -769,7 +769,7 @@ std::string GetCpuBitness() {
+ #elif BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_FUCHSIA)
+   return "64";
+ #elif BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop() ||
++  if (base::android::device_info::is_desktop_false() ||
+       base::android::device_info::is_xr()) {
+     return "64";
+   }
+@@ -843,7 +843,7 @@ std::string BuildModelInfo() {
+   if ((true)) return std::string();
+ #if BUILDFLAG(IS_ANDROID)
+   // Model information is not exposed on Android desktop.
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     return std::string();
+   }
+ 
+diff --git a/components/media_router/browser/android/media_router_android.cc b/components/media_router/browser/android/media_router_android.cc
+--- a/components/media_router/browser/android/media_router_android.cc
++++ b/components/media_router/browser/android/media_router_android.cc
+@@ -377,7 +377,7 @@ MediaRouterAndroid::GetFlingingController(const MediaRoute::Id& route_id) {
+   return bridge_->GetFlingingController(route_id);
+ }
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ MirroringMediaControllerHost*
+ MediaRouterAndroid::GetMirroringMediaControllerHost(
+     const MediaRoute::Id& route_id) {
+diff --git a/components/media_router/browser/android/media_router_android.h b/components/media_router/browser/android/media_router_android.h
+--- a/components/media_router/browser/android/media_router_android.h
++++ b/components/media_router/browser/android/media_router_android.h
+@@ -56,7 +56,7 @@ class MediaRouterAndroid : public MediaRouterBase {
+   std::unique_ptr<media::FlingingController> GetFlingingController(
+       const MediaRoute::Id& route_id) override;
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+   MirroringMediaControllerHost* GetMirroringMediaControllerHost(
+       const MediaRoute::Id& route_id) override;
+   IssueManager* GetIssueManager() override;
+diff --git a/components/media_router/browser/media_router.h b/components/media_router/browser/media_router.h
+--- a/components/media_router/browser/media_router.h
++++ b/components/media_router/browser/media_router.h
+@@ -29,7 +29,7 @@
+ #include "media/base/flinging_controller.h"
+ #include "third_party/blink/public/mojom/presentation/presentation.mojom.h"
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+ #include "components/media_router/browser/logger_impl.h"
+ #include "components/media_router/browser/media_router_debugger.h"
+ #include "components/media_router/common/mojom/media_controller.mojom.h"
+@@ -155,7 +155,7 @@ class MediaRouter : public KeyedService {
+   virtual std::unique_ptr<media::FlingingController> GetFlingingController(
+       const MediaRoute::Id& route_id) = 0;
+ 
+-#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE)
+   // Returns a pointer to a controller host that sends media commands related to
+   // mirroring within a route.
+   virtual MirroringMediaControllerHost* GetMirroringMediaControllerHost(
+diff --git a/components/policy/android/java/src/org/chromium/components/policy/CombinedPolicyProvider.java b/components/policy/android/java/src/org/chromium/components/policy/CombinedPolicyProvider.java
+--- a/components/policy/android/java/src/org/chromium/components/policy/CombinedPolicyProvider.java
++++ b/components/policy/android/java/src/org/chromium/components/policy/CombinedPolicyProvider.java
+@@ -60,10 +60,10 @@ public class CombinedPolicyProvider {
+ 
+         Log.i(TAG, "#linkNativeInternal() " + mPolicyProviders.size());
+ 
+-        if (mPolicyProviders.isEmpty()) {
+-            mPolicyCacheProvider = new PolicyCacheProvider();
+-            mPolicyCacheProvider.setManagerAndSource(this, /* source= */ 0);
+-        }
++        // if (mPolicyProviders.isEmpty()) {
++        //     mPolicyCacheProvider = new PolicyCacheProvider();
++        //     mPolicyCacheProvider.setManagerAndSource(this, /* source= */ 0);
++        // }
+         refreshPolicies();
+     }
+ 
+diff --git a/components/policy/android/java/src/org/chromium/components/policy/PolicyCacheUpdater.java b/components/policy/android/java/src/org/chromium/components/policy/PolicyCacheUpdater.java
+--- a/components/policy/android/java/src/org/chromium/components/policy/PolicyCacheUpdater.java
++++ b/components/policy/android/java/src/org/chromium/components/policy/PolicyCacheUpdater.java
+@@ -36,6 +36,6 @@ public class PolicyCacheUpdater {
+ 
+     @CalledByNative
+     public static void cachePolicies(PolicyMap policyMap) {
+-        PolicyCache.get().cachePolicies(policyMap, sPolicies);
++        //PolicyCache.get().cachePolicies(policyMap, sPolicies);
+     }
+ }
+diff --git a/components/policy/core/browser/android/policy_cache_updater_android.cc b/components/policy/core/browser/android/policy_cache_updater_android.cc
+--- a/components/policy/core/browser/android/policy_cache_updater_android.cc
++++ b/components/policy/core/browser/android/policy_cache_updater_android.cc
+@@ -45,7 +45,9 @@ PolicyCacheUpdater::~PolicyCacheUpdater() {
+ void PolicyCacheUpdater::OnPolicyUpdated(const PolicyNamespace& ns,
+                                          const PolicyMap& previous,
+                                          const PolicyMap& current) {
+-  UpdateCache(current);
++  if (ns.domain == POLICY_DOMAIN_CHROME) {
++    UpdateCache(current);
++  }
+ }
+ 
+ void PolicyCacheUpdater::UpdateCache(const PolicyMap& current_policy_map) {
+diff --git a/components/policy/core/browser/cloud/user_policy_signin_service_base.cc b/components/policy/core/browser/cloud/user_policy_signin_service_base.cc
+--- a/components/policy/core/browser/cloud/user_policy_signin_service_base.cc
++++ b/components/policy/core/browser/cloud/user_policy_signin_service_base.cc
+@@ -37,7 +37,7 @@ namespace {
+ 
+ em::DeviceRegisterRequest::Type GetCloudPolicyRegistrationType() {
+ #if BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     return em::DeviceRegisterRequest::BROWSER;
+   } else {
+     return em::DeviceRegisterRequest::ANDROID_BROWSER;
+diff --git a/components/policy/core/browser/configuration_policy_handler_list.cc b/components/policy/core/browser/configuration_policy_handler_list.cc
+--- a/components/policy/core/browser/configuration_policy_handler_list.cc
++++ b/components/policy/core/browser/configuration_policy_handler_list.cc
+@@ -101,7 +101,7 @@ void ConfigurationPolicyHandlerList::PrepareForDisplaying(
+ 
+ bool ConfigurationPolicyHandlerList::IsBlockedDesktopAndroidPolicy(
+     const std::string& policy_name) const {
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+   // The allowlist is not used if kDesktopAndroidPolicy is off. So that all
+   // policies are allowed by default without Finch config.
+   if (!base::FeatureList::IsEnabled(features::kDesktopAndroidPolicy)) {
+@@ -173,7 +173,7 @@ bool ConfigurationPolicyHandlerList::IsBlockedFuturePolicy(
+     const base::flat_set<std::string>& future_policies_allowed,
+     const PolicyDetails& policy_details,
+     PolicyMap::const_reference entry) const {
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   if (base::FeatureList::IsEnabled(features::kFuturePoliciesOnDesktopAndroid) &&
+       policy_details.is_future) {
+     return false;
+diff --git a/components/policy/core/common/cloud/cloud_policy_constants.cc b/components/policy/core/common/cloud/cloud_policy_constants.cc
+--- a/components/policy/core/common/cloud/cloud_policy_constants.cc
++++ b/components/policy/core/common/cloud/cloud_policy_constants.cc
+@@ -142,7 +142,7 @@ const char* GetChromeUserPolicyType() {
+ #if BUILDFLAG(IS_CHROMEOS)
+   return "google/chromeos/user";
+ #elif BUILDFLAG(IS_ANDROID)
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     return "google/chrome/user";
+   } else {
+     return "google/android/user";
+diff --git a/components/policy/core/common/features.cc b/components/policy/core/common/features.cc
+--- a/components/policy/core/common/features.cc
++++ b/components/policy/core/common/features.cc
+@@ -39,7 +39,7 @@ const base::FeatureParam<base::TimeDelta> kPolicyRegistrationDelay{
+ // Used to add a captive portal check in SafeSitesNavigationThrottle.
+ BASE_FEATURE(kSafeSitesCaptivePortalCheck, base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ // TODO(https://crbug.com/452666657): Remove this feature flag after launching
+ // policies to supported on Android Desktop.
+ BASE_FEATURE(kFuturePoliciesOnDesktopAndroid,
+diff --git a/components/policy/core/common/policy_merger.cc b/components/policy/core/common/policy_merger.cc
+--- a/components/policy/core/common/policy_merger.cc
++++ b/components/policy/core/common/policy_merger.cc
+@@ -21,7 +21,7 @@ namespace policy {
+ namespace {
+ 
+ #if !BUILDFLAG(IS_IOS) && !BUILDFLAG(IS_FUCHSIA) && (!BUILDFLAG(IS_ANDROID) || \
+-    BUILDFLAG(IS_DESKTOP_ANDROID))
++    BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM))
+ constexpr const char* kDictionaryPoliciesToMerge[] = {
+ #if BUILDFLAG(IS_CHROMEOS)
+     key::kExtensionSettings,       key::kDeviceLoginScreenPowerManagement,
+@@ -190,7 +190,7 @@ void PolicyListMerger::DoMerge(PolicyMap::Entry* policy) const {
+ PolicyDictionaryMerger::PolicyDictionaryMerger(
+     base::flat_set<std::string> policies_to_merge)
+ #if BUILDFLAG(IS_IOS) || BUILDFLAG(IS_FUCHSIA) || \
+-    (BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID))
++    (BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM))
+     : policies_to_merge_(std::move(policies_to_merge)){}
+ #else
+     : policies_to_merge_(std::move(policies_to_merge)),
+diff --git a/components/webapps/browser/installable/installable_icon_fetcher.cc b/components/webapps/browser/installable/installable_icon_fetcher.cc
+--- a/components/webapps/browser/installable/installable_icon_fetcher.cc
++++ b/components/webapps/browser/installable/installable_icon_fetcher.cc
+@@ -120,7 +120,7 @@ void ProcessFaviconInBackground(
+       FROM_HERE, base::BindOnce(std::move(success_callback), decoded));
+ }
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ // Generates a homescreen icon for `page_url` and posts a task to invoke
+ // `callback` on `ui_thread_task_runner.`
+ void GenerateHomeScreenIconInBackground(
+@@ -261,7 +261,7 @@ void InstallableIconFetcher::OnIconFetched(const GURL& icon_url,
+ }
+ 
+ void InstallableIconFetcher::MaybeEndWithError(InstallableStatusCode code) {
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   // Desktop android will generate an icon if none is available.
+   base::ThreadPool::PostTask(
+       FROM_HERE,
+@@ -285,7 +285,7 @@ void InstallableIconFetcher::EndWithError(InstallableStatusCode code) {
+   std::move(finish_callback_).Run(code);
+ }
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+ void InstallableIconFetcher::OnHomeScreenIconGenerated(const GURL& page_url,
+                                                        const SkBitmap& bitmap) {
+   if (bitmap.drawsNothing()) {
+diff --git a/components/webapps/browser/installable/installable_icon_fetcher.h b/components/webapps/browser/installable/installable_icon_fetcher.h
+--- a/components/webapps/browser/installable/installable_icon_fetcher.h
++++ b/components/webapps/browser/installable/installable_icon_fetcher.h
+@@ -68,7 +68,7 @@ class InstallableIconFetcher {
+   // Ends the fetch with an error.
+   void EndWithError(InstallableStatusCode code);
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   void OnHomeScreenIconGenerated(const GURL& page_url, const SkBitmap& bitmap);
+ #endif
+ 
+diff --git a/components/webui/version/resources/about_version.html b/components/webui/version/resources/about_version.html
+--- a/components/webui/version/resources/about_version.html
++++ b/components/webui/version/resources/about_version.html
+@@ -105,7 +105,7 @@ about:version template page
+             <span>$i18n{gms_version}</span>
+           </td>
+         </tr>
+-<if expr="is_desktop_android">
++<if expr="is_desktop_android_false_thorium">
+         <tr>
+           <td class="label">Desktop Android</td>
+           <td class="version">true</td>
+diff --git a/content/browser/android/selection/selection_popup_controller.cc b/content/browser/android/selection/selection_popup_controller.cc
+--- a/content/browser/android/selection/selection_popup_controller.cc
++++ b/content/browser/android/selection/selection_popup_controller.cc
+@@ -347,6 +347,11 @@ void SelectionPopupController::OnSelectAroundCaretAck(
+       result->word_start_adjust, result->word_end_adjust);
+ }
+ 
++void SelectionPopupController::DismissMenu() {
++  menu_model_bridge_.reset();
++  extra_items_menu_model_.reset();
++}
++
+ void SelectionPopupController::HidePopupsAndPreserveSelection() {
+   JNIEnv* env = AttachCurrentThread();
+   ScopedJavaLocalRef<jobject> obj = java_obj_.get(env);
+diff --git a/content/browser/android/selection/selection_popup_controller.h b/content/browser/android/selection/selection_popup_controller.h
+--- a/content/browser/android/selection/selection_popup_controller.h
++++ b/content/browser/android/selection/selection_popup_controller.h
+@@ -70,6 +70,7 @@ class SelectionPopupController : public RenderWidgetHostConnector {
+                               int endOffset,
+                               int surroundingTextLength,
+                               blink::mojom::SelectAroundCaretResultPtr result);
++  void DismissMenu();
+   void HidePopupsAndPreserveSelection();
+   void RestoreSelectionPopupsIfNecessary();
+   void ChildLocalSurfaceIdChanged();
+diff --git a/content/browser/browser_main_loop.cc b/content/browser/browser_main_loop.cc
+--- a/content/browser/browser_main_loop.cc
++++ b/content/browser/browser_main_loop.cc
+@@ -849,7 +849,7 @@ int BrowserMainLoop::PreCreateThreads() {
+   base::UmaHistogramBoolean("SiteIsolation.IsSitePerProcessOrStricter",
+                             SiteIsolationPolicy::IsSitePerProcessOrStricter());
+ 
+-#if BUILDFLAG(IS_ANDROID) && BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   base::UmaHistogramBoolean(
+       "SiteIsolation.IsSitePerProcessOrStricter.AndroidDesktop",
+       SiteIsolationPolicy::IsSitePerProcessOrStricter());
+diff --git a/content/browser/renderer_host/media/video_capture_manager.cc b/content/browser/renderer_host/media/video_capture_manager.cc
+--- a/content/browser/renderer_host/media/video_capture_manager.cc
++++ b/content/browser/renderer_host/media/video_capture_manager.cc
+@@ -120,7 +120,7 @@ void VideoCaptureManager::RegisterListener(
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+   DCHECK(listener);
+   listeners_.AddObserver(listener);
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+   application_state_has_running_activities_ = true;
+   app_status_listener_ =
+       base::android::ApplicationStatusListener::New(base::BindRepeating(
+@@ -952,7 +952,7 @@ VideoCaptureManager::GetOrCreateController(
+   return new_controller;
+ }
+ 
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+ void VideoCaptureManager::OnApplicationStateChange(
+     base::android::ApplicationState state) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+diff --git a/content/browser/renderer_host/media/video_capture_manager.h b/content/browser/renderer_host/media/video_capture_manager.h
+--- a/content/browser/renderer_host/media/video_capture_manager.h
++++ b/content/browser/renderer_host/media/video_capture_manager.h
+@@ -36,7 +36,7 @@
+ #include "media/capture/video_capture_types.h"
+ #include "ui/gfx/native_ui_types.h"
+ 
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+ #include "base/android/application_status_listener.h"
+ #endif
+ 
+@@ -211,7 +211,7 @@ class CONTENT_EXPORT VideoCaptureManager
+   void TakePhoto(const base::UnguessableToken& session_id,
+                  VideoCaptureDevice::TakePhotoCallback callback);
+ 
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+   // Some devices had troubles when stopped and restarted quickly, so the device
+   // is only stopped when Chrome is sent to background and not when, e.g., a tab
+   // is hidden, see http://crbug.com/582295.
+@@ -327,7 +327,7 @@ class CONTENT_EXPORT VideoCaptureManager
+   void ReleaseDevices();
+   void ResumeDevices();
+ 
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+   std::unique_ptr<base::android::ApplicationStatusListener>
+       app_status_listener_;
+   bool application_state_has_running_activities_;
+diff --git a/content/browser/renderer_host/render_widget_host_view_android.cc b/content/browser/renderer_host/render_widget_host_view_android.cc
+--- a/content/browser/renderer_host/render_widget_host_view_android.cc
++++ b/content/browser/renderer_host/render_widget_host_view_android.cc
+@@ -184,7 +184,7 @@ bool IsTooltipsEnabled() {
+   // Only show on desktop devices up to B due to tooltips bug b/445244223.
+   if (base::android::android_info::sdk_int() <=
+       base::android::android_info::SDK_VERSION_BAKLAVA) {
+-    return base::android::device_info::is_desktop();
++    return base::android::device_info::is_desktop_false();
+   }
+ 
+   return true;
+diff --git a/content/public/android/java/src/org/chromium/content/browser/ContentUiEventHandler.java b/content/public/android/java/src/org/chromium/content/browser/ContentUiEventHandler.java
+--- a/content/public/android/java/src/org/chromium/content/browser/ContentUiEventHandler.java
++++ b/content/public/android/java/src/org/chromium/content/browser/ContentUiEventHandler.java
+@@ -123,9 +123,10 @@ public class ContentUiEventHandler implements UserData {
+                         event,
+                         MotionEventUtils.getEventTimeNanos(event),
+                         EventForwarder.getMouseEventActionButton(event),
+-                        shouldConvertToMouseEvent
+-                                ? MotionEvent.TOOL_TYPE_MOUSE
+-                                : event.getToolType(0));
++                        MotionEvent.TOOL_TYPE_FINGER);
++                        // shouldConvertToMouseEvent
++                        //         ? MotionEvent.TOOL_TYPE_MOUSE
++                        //         : event.getToolType(0));
+         if (didOffsetEvent) event.recycle();
+         return true;
+     }
+diff --git a/content/public/android/java/src/org/chromium/content/browser/selection/SelectionPopupControllerImpl.java b/content/public/android/java/src/org/chromium/content/browser/selection/SelectionPopupControllerImpl.java
+--- a/content/public/android/java/src/org/chromium/content/browser/selection/SelectionPopupControllerImpl.java
++++ b/content/public/android/java/src/org/chromium/content/browser/selection/SelectionPopupControllerImpl.java
+@@ -762,6 +762,9 @@ public class SelectionPopupControllerImpl extends ActionModeCallbackHelper
+      */
+     @Override
+     public void finishActionMode() {
++        SelectionPopupControllerImplJni.get()
++                .dismissMenu(mNativeSelectionPopupController);
++
+         mHidden = false;
+         mHandler.removeCallbacks(mRepeatingHideRunnable);
+ 
+@@ -1976,6 +1979,8 @@ public class SelectionPopupControllerImpl extends ActionModeCallbackHelper
+ 
+         void setTextHandlesTemporarilyHidden(long nativeSelectionPopupController, boolean hidden);
+ 
++        void dismissMenu(long nativeSelectionPopupController);
++
+         void setTextHandlesHiddenForDropdownMenu(
+                 long nativeSelectionPopupController, boolean hidden);
+ 
+diff --git a/content/public/common/content_features.cc b/content/public/common/content_features.cc
+--- a/content/public/common/content_features.cc
++++ b/content/public/common/content_features.cc
+@@ -588,7 +588,7 @@ BASE_FEATURE(kLoadingPredictorLimitPreconnectSocketCount,
+              base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kLogJsConsoleMessages,
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+              base::FEATURE_DISABLED_BY_DEFAULT
+ #else
+              base::FEATURE_ENABLED_BY_DEFAULT
+diff --git a/content/public/renderer/render_frame_media_playback_options.cc b/content/public/renderer/render_frame_media_playback_options.cc
+--- a/content/public/renderer/render_frame_media_playback_options.cc
++++ b/content/public/renderer/render_frame_media_playback_options.cc
+@@ -22,7 +22,7 @@ bool IsBackgroundMediaSuspendEnabled() {
+   if (base::FeatureList::IsEnabled(
+           features::kAndroidEnableBackgroundMediaLargeFormFactors) &&
+       (base::android::device_info::is_tablet() ||
+-       base::android::device_info::is_desktop())) {
++       base::android::device_info::is_desktop_false())) {
+     // Do not suspend background media if feature is enabled AND it was launched
+     // on a large display. Feature is enabled by default except for WebView
+     return false;
+diff --git a/thorium_flags/chrome/browser/about_flags_cc/Extensions-Android.inc b/thorium_flags/chrome/browser/about_flags_cc/Extensions-Android.inc
+new file mode 100644
+--- /dev/null
++++ b/thorium_flags/chrome/browser/about_flags_cc/Extensions-Android.inc
+@@ -0,0 +1,12 @@
++#ifdef FLAG_SECTION
++
++#if BUILDFLAG(IS_ANDROID)
++
++    {"enable-extensions-android",
++     "Enable Extensions Android",
++     "Allows the use of extensions on Android", kOsAndroid,
++     FEATURE_VALUE_TYPE(extensions_features::kEnableExtensionsAndroid)},
++
++#endif
++
++#endif // ifdef FLAG_SECTION
+diff --git a/thorium_flags/chrome/browser/about_flags_cc/Webstore-protection.inc b/thorium_flags/chrome/browser/about_flags_cc/Webstore-protection.inc
+--- a/thorium_flags/chrome/browser/about_flags_cc/Webstore-protection.inc
++++ b/thorium_flags/chrome/browser/about_flags_cc/Webstore-protection.inc
+@@ -1,19 +1,15 @@
+ #ifdef FLAG_SECTION
+ 
+-#if !BUILDFLAG(IS_ANDROID)
+-
+     {"enable-extension-autoupdate",
+      "Enable Extensions Autoupdate",
+      "Allows the auto-updating of installed extensions by sending the "
+-     "minimum required data.", kOsDesktop,
++     "minimum required data.", kOsAll,
+      FEATURE_VALUE_TYPE(extensions_features::kEnableExtensionAutoupdate)},
+ 
+     {"enable-extension-management-to-chrome-store",
+      "Allow full use of management api to chrome web store",
+      "When deactivated (default) allows installation but hide "
+-     "to the webstore which extensions are installed on the device.", kOsDesktop,
++     "to the webstore which extensions are installed on the device.", kOsAll,
+      FEATURE_VALUE_TYPE(extensions_features::kEnableExtensionManagementToChromeStore)},
+ 
+-#endif // !BUILDFLAG(IS_ANDROID)
+-
+ #endif // ifdef FLAG_SECTION
+diff --git a/extensions/browser/BUILD.gn b/extensions/browser/BUILD.gn
+--- a/extensions/browser/BUILD.gn
++++ b/extensions/browser/BUILD.gn
+@@ -10,7 +10,7 @@ import("//pdf/features.gni")
+ import("//rlz/buildflags/buildflags.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+-if (enable_desktop_android_extensions) {
++if (enable_desktop_android_extensions_thorium) {
+   import("//build/config/android/rules.gni")
+ }
+ 
+@@ -1186,7 +1186,7 @@ source_set("unit_tests") {
+   configs += [ "//build/config/compiler:no_exit_time_destructors" ]
+ }
+ 
+-if (enable_desktop_android_extensions) {
++if (enable_desktop_android_extensions_thorium) {
+   java_cpp_enum("extension_action_enums") {
+     sources = [ "extension_action.h" ]
+   }
+diff --git a/extensions/browser/api/api_browser_context_keyed_service_factories.cc b/extensions/browser/api/api_browser_context_keyed_service_factories.cc
+--- a/extensions/browser/api/api_browser_context_keyed_service_factories.cc
++++ b/extensions/browser/api/api_browser_context_keyed_service_factories.cc
+@@ -69,7 +69,7 @@
+ 
+ namespace extensions {
+ 
+-void EnsureApiBrowserContextKeyedServiceFactoriesBuilt() {
++void EnsureApiBrowserContextKeyedServiceFactoriesBuilt() { //
+   AlarmManager::GetFactoryInstance();
+   declarative_net_request::RulesMonitorService::GetFactoryInstance();
+   IdleManagerFactory::GetInstance();
+diff --git a/extensions/browser/api/system_cpu/BUILD.gn b/extensions/browser/api/system_cpu/BUILD.gn
+--- a/extensions/browser/api/system_cpu/BUILD.gn
++++ b/extensions/browser/api/system_cpu/BUILD.gn
+@@ -36,7 +36,7 @@ source_set("system_cpu") {
+     sources += [ "cpu_info_provider_mac.cc" ]
+   }
+ 
+-  if (is_linux || is_chromeos || enable_desktop_android_extensions) {
++  if (is_linux || is_chromeos || enable_desktop_android_extensions_thorium) {
+     sources += [ "cpu_info_provider_linux.cc" ]
+   }
+ 
+diff --git a/extensions/browser/api/web_request/permission_helper.cc b/extensions/browser/api/web_request/permission_helper.cc
+--- a/extensions/browser/api/web_request/permission_helper.cc
++++ b/extensions/browser/api/web_request/permission_helper.cc
+@@ -64,7 +64,7 @@ void BrowserContextKeyedAPIFactory<
+   // implicitly depends upon those.
+   ExtensionsAPIClient* extensions_api_client = ExtensionsAPIClient::Get();
+ 
+-#if BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   // TODO(https://crbug.com/356905053): On Android, the startup and
+   // initialization flow is different.
+   // ExtensionsAPIClient is instantiated as part of the ExtensionsBrowserClient,
+diff --git a/extensions/browser/extension_frame_host.cc b/extensions/browser/extension_frame_host.cc
+--- a/extensions/browser/extension_frame_host.cc
++++ b/extensions/browser/extension_frame_host.cc
+@@ -157,6 +157,10 @@ void ExtensionFrameHost::OpenChannelToExtension(
+   TRACE_EVENT("extensions", "ExtensionFrameHost::OpenChannelToExtension",
+               ChromeTrackEvent::kRenderProcessHost, *process);
+ 
++  if (!MessageServiceApi::GetMessageService()) {
++    LOG(INFO) << "--No MessageServiceApi";
++    return;
++  }
+   MessageServiceApi::GetMessageService()->OpenChannelToExtension(
+       render_frame_host->GetBrowserContext(), render_frame_host, port_id, *info,
+       channel_type, channel_name, std::move(port), std::move(port_host));
+@@ -189,6 +193,10 @@ void ExtensionFrameHost::OpenChannelToTab(
+     mojo::PendingAssociatedRemote<extensions::mojom::MessagePort> port,
+     mojo::PendingAssociatedReceiver<extensions::mojom::MessagePortHost>
+         port_host) {
++  if (!MessageServiceApi::GetMessageService()) {
++    LOG(INFO) << "--No MessageServiceApi";
++    return;
++  }
+   content::RenderFrameHost* render_frame_host =
+       receivers_.GetCurrentTargetFrame();
+   auto* process = render_frame_host->GetProcess();
+diff --git a/extensions/browser/extension_host.cc b/extensions/browser/extension_host.cc
+--- a/extensions/browser/extension_host.cc
++++ b/extensions/browser/extension_host.cc
+@@ -14,6 +14,7 @@
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/timer/elapsed_timer.h"
++#include "components/embedder_support/user_agent_utils.h"
+ #include "components/input/native_web_keyboard_event.h"
+ #include "components/javascript_dialogs/app_modal_dialog_manager.h"
+ #include "content/public/browser/browser_context.h"
+@@ -323,9 +324,26 @@ const GURL& ExtensionHost::GetLastCommittedURL() const {
+ 
+ void ExtensionHost::LoadInitialURL() {
+   load_start_ = std::make_unique<base::ElapsedTimer>();
+-  host_contents_->GetController().LoadURL(
+-      initial_url_, content::Referrer(), ui::PAGE_TRANSITION_LINK,
+-      std::string());
++
++  content::NavigationController::LoadURLParams params(initial_url_);
++  params.referrer = content::Referrer();
++  params.transition_type = ui::PAGE_TRANSITION_LINK;
++  params.extra_headers = std::string();
++
++#if BUILDFLAG(IS_ANDROID)
++  if (extension_host_type() == mojom::ViewType::kExtensionPopup) {
++    constexpr char kOsOverrideForCromite[] = "Linux; Android 10; Cromite";
++    const std::string product = embedder_support::GetProductAndVersion();
++    blink::UserAgentOverride ua_override;
++    ua_override.ua_string_override =
++        embedder_support::BuildUserAgentFromOSAndProduct(kOsOverrideForCromite,
++                                                        product);
++    host_contents_->SetUserAgentOverride(ua_override,
++                                         false /*override_in_new_tabs=*/);
++    params.override_user_agent = content::NavigationController::UA_OVERRIDE_TRUE;
++  }
++#endif
++  host_contents_->GetController().LoadURLWithParams(params);
+ }
+ 
+ bool ExtensionHost::IsBackgroundPage() const {
+diff --git a/extensions/buildflags/BUILD.gn b/extensions/buildflags/BUILD.gn
+--- a/extensions/buildflags/BUILD.gn
++++ b/extensions/buildflags/BUILD.gn
+@@ -16,7 +16,8 @@ buildflag_header("buildflags") {
+   header = "buildflags.h"
+   flags = [
+     "ENABLE_EXTENSIONS=$enable_extensions",
+-    "ENABLE_DESKTOP_ANDROID_EXTENSIONS=$enable_desktop_android_extensions",
++    "ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE=$enable_desktop_android_extensions_thorium",
++    "ENABLE_DESKTOP_ANDROID_EXTENSIONS_FALSE=false",
+     "ENABLE_EXTENSIONS_CORE=$enable_extensions_core",
+     "ENABLE_PLATFORM_APPS=$enable_platform_apps",
+   ]
+diff --git a/extensions/buildflags/buildflags.gni b/extensions/buildflags/buildflags.gni
+--- a/extensions/buildflags/buildflags.gni
++++ b/extensions/buildflags/buildflags.gni
+@@ -27,7 +27,7 @@ declare_args() {
+   #
+   # TODO(https://crbug.com/356905053): Continue expanding the scope of
+   # enable_desktop_android_extensions.
+-  enable_desktop_android_extensions = is_desktop_android
++  enable_desktop_android_extensions_thorium = is_android
+ }
+ 
+ # Note: GN forbids relying on args from the same declare_args() block, so we
+@@ -45,5 +45,5 @@ declare_args() {
+   # `if (enable_extensions || enable_desktop_android_extensions)`, since the
+   # core handling in each of these implementations is similar.
+   enable_extensions_core =
+-      enable_extensions || enable_desktop_android_extensions
++      enable_extensions || enable_desktop_android_extensions_thorium
+ }
+diff --git a/extensions/common/api/schema.gni b/extensions/common/api/schema.gni
+--- a/extensions/common/api/schema.gni
++++ b/extensions/common/api/schema.gni
+@@ -110,7 +110,7 @@ if (enable_extensions) {
+ # the C++ types for certain APIs, since they are used from outside the
+ # extensions layer. These should be removed as we add support for the full
+ # API by moving these entries to the `extensions_api_schema_files_` above.
+-if (enable_desktop_android_extensions) {
++if (enable_desktop_android_extensions_thorium) {
+   extensions_types_only_schema_files_ += [
+     "clipboard.webidl",
+     "scripts_internal.idl",
+diff --git a/extensions/common/command.cc b/extensions/common/command.cc
+--- a/extensions/common/command.cc
++++ b/extensions/common/command.cc
+@@ -119,7 +119,7 @@ std::string Command::CommandPlatform() {
+   return ui::kKeybindingPlatformChromeOs;
+ #elif BUILDFLAG(IS_LINUX)
+   return ui::kKeybindingPlatformLinux;
+-#elif BUILDFLAG(IS_DESKTOP_ANDROID)
++#elif BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   // For now, we use linux keybindings on desktop android.
+   return ui::kKeybindingPlatformLinux;
+ #else
+diff --git a/extensions/common/extension_features.cc b/extensions/common/extension_features.cc
+--- a/extensions/common/extension_features.cc
++++ b/extensions/common/extension_features.cc
+@@ -60,7 +60,7 @@ BASE_FEATURE(kSkipResetServiceWorkerURLLoaderFactories,
+ 
+ BASE_FEATURE(kEnableWebHidInWebView, base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ // Disabled by default because on first-run we don't have a Finch seed yet, so
+ // we want to default to the safe behavior of no extensions.
+ BASE_FEATURE(kEnableExtensionsForCorpDesktopAndroid,
+@@ -177,7 +177,7 @@ BASE_FEATURE(kDisableExtensionsOnChromeUrlsSwitch,
+ // TODO (crbug.com/426554244): Determine if this switch should be
+ // removed for desktop-android builds as well.
+ #if BUILDFLAG(GOOGLE_CHROME_BRANDING) && !BUILDFLAG(IS_CHROMEOS) && \
+-    !BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++    !BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+              base::FEATURE_ENABLED_BY_DEFAULT
+ #else
+              base::FEATURE_DISABLED_BY_DEFAULT
+@@ -225,4 +225,10 @@ CROMITE_FEATURE(kEnableExtensionAutoupdate,
+ CROMITE_FEATURE(kEnableExtensionManagementToChromeStore,
+                 "EnableExtensionToChromeStore",
+                 base::FEATURE_DISABLED_BY_DEFAULT);
++
++#if BUILDFLAG(IS_ANDROID)
++CROMITE_FEATURE(kEnableExtensionsAndroid,
++                "EnableExtensionsAndroid",
++                base::FEATURE_DISABLED_BY_DEFAULT);
++#endif
+ }  // namespace extensions_features
+diff --git a/extensions/common/extension_features.h b/extensions/common/extension_features.h
+--- a/extensions/common/extension_features.h
++++ b/extensions/common/extension_features.h
+@@ -103,7 +103,7 @@ BASE_DECLARE_FEATURE(kSkipResetServiceWorkerURLLoaderFactories);
+ // embedding Chrome App to request access to Human Interface Devices.
+ BASE_DECLARE_FEATURE(kEnableWebHidInWebView);
+ 
+-#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+ // If enabled, extensions will be enabled for @google.com and @managedchrome.com
+ // users on desktop Android. Otherwise they will be blocked.
+ BASE_DECLARE_FEATURE(kEnableExtensionsForCorpDesktopAndroid);
+@@ -343,6 +343,10 @@ BASE_DECLARE_FEATURE(kEnableExtensionAutoupdate);
+ // Allows the installation of new extensions.
+ // If active, exposes all features to the chrome web store like chromium.
+ BASE_DECLARE_FEATURE(kEnableExtensionManagementToChromeStore);
++
++#if BUILDFLAG(IS_ANDROID)
++BASE_DECLARE_FEATURE(kEnableExtensionsAndroid);
++#endif
+ }  // namespace extensions_features
+ 
+ #endif  // EXTENSIONS_COMMON_EXTENSION_FEATURES_H_
+diff --git a/extensions/common/extension_l10n_util.cc b/extensions/common/extension_l10n_util.cc
+--- a/extensions/common/extension_l10n_util.cc
++++ b/extensions/common/extension_l10n_util.cc
+@@ -470,8 +470,10 @@ bool GetValidLocales(const base::FilePath& locale_path,
+   }
+ 
+   if (valid_locales->empty()) {
++#if !BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+     *error = errors::kLocalesNoValidLocaleNamesListed;
+     return false;
++#endif
+   }
+ 
+   return true;
+@@ -566,7 +568,11 @@ bool ShouldSkipValidation(const base::FilePath& locales_path,
+   // '.svn' directories.
+   base::FilePath relative_path;
+   if (!locales_path.AppendRelativePath(locale_path, &relative_path)) {
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
++    return true;
++#else
+     NOTREACHED();
++#endif
+   }
+   std::string subdir = relative_path.MaybeAsASCII();
+   if (subdir.empty())
+diff --git a/extensions/common/features/feature.cc b/extensions/common/features/feature.cc
+--- a/extensions/common/features/feature.cc
++++ b/extensions/common/features/feature.cc
+@@ -28,7 +28,7 @@ Feature::Platform Feature::GetCurrentPlatform() {
+   return MACOSX_PLATFORM;
+ #elif BUILDFLAG(IS_WIN)
+   return WIN_PLATFORM;
+-#elif BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS)
++#elif BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
+   return DESKTOP_ANDROID_PLATFORM;
+ #else
+   return UNSPECIFIED_PLATFORM;
+diff --git a/extensions/common/manifest_handlers/default_locale_handler.cc b/extensions/common/manifest_handlers/default_locale_handler.cc
+--- a/extensions/common/manifest_handlers/default_locale_handler.cc
++++ b/extensions/common/manifest_handlers/default_locale_handler.cc
+@@ -115,6 +115,9 @@ bool DefaultLocaleHandler::Validate(
+ 
+   // Only message file for default locale has to exist.
+   if (!has_default_locale_message_file) {
++#if BUILDFLAG(ENABLE_DESKTOP_ANDROID_EXTENSIONS_CROMITE)
++    if (base::PathExists(default_locale_path)) return true;
++#endif
+     *error = errors::kLocalesNoDefaultMessages;
+     return false;
+   }
+diff --git a/extensions/renderer/bindings/api_binding_util.cc b/extensions/renderer/bindings/api_binding_util.cc
+--- a/extensions/renderer/bindings/api_binding_util.cc
++++ b/extensions/renderer/bindings/api_binding_util.cc
+@@ -148,7 +148,7 @@ std::string GetPlatformString() {
+   return "mac";
+ #elif BUILDFLAG(IS_WIN)
+   return "win";
+-#elif BUILDFLAG(IS_DESKTOP_ANDROID)
++#elif BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   return "desktop_android";
+ #else
+   NOTREACHED();
+diff --git a/gpu/config/gpu_finch_features.cc b/gpu/config/gpu_finch_features.cc
+--- a/gpu/config/gpu_finch_features.cc
++++ b/gpu/config/gpu_finch_features.cc
+@@ -607,7 +607,7 @@ bool IsSkiaGraphiteSupportedByDevice(const base::CommandLine* command_line) {
+   // Desktop Android isn't ready to pick up the fieldtrial_testing_config.json
+   // change that enables graphite. However, it's the same platform as regular
+   // Android and does. Skip enabling the feature there for now.
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     return false;
+   }
+ 
+@@ -720,7 +720,7 @@ bool ShouldEnableDrDc() {
+   // Chrome on Android desktop aims to be Vulkan-only, which can result
+   // in crashes when enabled together with DrDc. Re-enable DrDc after
+   // crbug.com/380295059 is fixed if it is shown beneficial on desktop.
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     return false;
+   }
+ #endif
+diff --git a/net/features.gni b/net/features.gni
+--- a/net/features.gni
++++ b/net/features.gni
+@@ -30,8 +30,8 @@ declare_args() {
+   disable_zstd_filter = false
+ 
+   # Multicast DNS. Enabled on desktop Android for the chrome.mdns extension API.
+-  enable_mdns = is_win || is_linux || is_chromeos || is_fuchsia || is_apple ||
+-                enable_desktop_android_extensions
++  enable_mdns = is_win || is_linux || is_chromeos || is_fuchsia || is_apple
++                #|| enable_desktop_android_extensions
+ 
+   # Reporting not used on iOS.
+   enable_reporting = !is_ios
+diff --git a/skia/features.gni b/skia/features.gni
+--- a/skia/features.gni
++++ b/skia/features.gni
+@@ -12,7 +12,7 @@ declare_args() {
+   skia_use_dawn =
+       is_mac || is_win ||
+       (is_android && target_cpu != "x86" && target_cpu != "x64") ||
+-      (is_ios && use_blink) || (is_linux && !is_castos) || is_desktop_android
++      (is_ios && use_blink) || (is_linux && !is_castos) || is_desktop_android_false_thorium
+ 
+   # Enable experimental Skia Graphite Metal backend. Intended only for debugging
+   # on non-official developer builds on Mac and iOS Blink.
+diff --git a/third_party/blink/common/features.cc b/third_party/blink/common/features.cc
+--- a/third_party/blink/common/features.cc
++++ b/third_party/blink/common/features.cc
+@@ -2365,7 +2365,7 @@ BASE_FEATURE(kStopInBackground,
+ // b/248036988 - Disable this for Chromecast on Android builds to prevent apps
+ // that play audio in the background from stopping.
+ #if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CAST_ANDROID) && \
+-    !BUILDFLAG(IS_DESKTOP_ANDROID)
++    !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+              base::FEATURE_ENABLED_BY_DEFAULT
+ #else
+              base::FEATURE_DISABLED_BY_DEFAULT
+diff --git a/third_party/blink/renderer/modules/modules_initializer.cc b/third_party/blink/renderer/modules/modules_initializer.cc
+--- a/third_party/blink/renderer/modules/modules_initializer.cc
++++ b/third_party/blink/renderer/modules/modules_initializer.cc
+@@ -120,7 +120,7 @@
+ namespace blink {
+ namespace {
+ 
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+ 
+ class SuspendCaptureObserver : public GarbageCollected<SuspendCaptureObserver>,
+                                public Supplement<Page>,
+@@ -374,7 +374,7 @@ void ModulesInitializer::ProvideModulesToPage(
+     const SessionStorageNamespaceId& namespace_id) const {
+   StorageNamespace::ProvideSessionStorageNamespaceTo(page, namespace_id);
+   AudioGraphTracer::ProvideAudioGraphTracerTo(page);
+-#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID)
++#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_DESKTOP_ANDROID_FALSE)
+   page.ProvideSupplement(MakeGarbageCollected<SuspendCaptureObserver>(page));
+ #endif  // BUILDFLAG(IS_ANDROID)  && !BUILDFLAG(IS_DESKTOP_ANDROID)
+ }
+diff --git a/tools/grit/grit_args.gni b/tools/grit/grit_args.gni
+--- a/tools/grit/grit_args.gni
++++ b/tools/grit/grit_args.gni
+@@ -34,7 +34,8 @@ _grit_defines = [
+   # Mac wants Title Case strings.
+   "use_titlecase=${is_mac}",
+ 
+-  "is_desktop_android=${is_desktop_android}",
++  "is_desktop_android_false_thorium=${is_desktop_android_false_thorium}",
++  "is_desktop_android_thorium=${is_desktop_android_thorium}",
+ ]
+ 
+ # Must match `enable_hidpi` in ui/base/ui_features.gni.
+diff --git a/tools/json_schema_compiler/cpp_bundle_generator.py b/tools/json_schema_compiler/cpp_bundle_generator.py
+--- a/tools/json_schema_compiler/cpp_bundle_generator.py
++++ b/tools/json_schema_compiler/cpp_bundle_generator.py
+@@ -138,7 +138,7 @@ class CppBundleGenerator(object):
+       if platform == Platforms.CHROMEOS:
+         ifdefs.append('BUILDFLAG(IS_CHROMEOS)')
+       elif platform == Platforms.DESKTOP_ANDROID:
+-        ifdefs.append('BUILDFLAG(IS_DESKTOP_ANDROID)')
++        ifdefs.append('BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)')
+       elif platform == Platforms.LINUX:
+         ifdefs.append('BUILDFLAG(IS_LINUX)')
+       elif platform == Platforms.MAC:
+diff --git a/ui/android/java/src/org/chromium/ui/widget/PopupSpecCalculator.java b/ui/android/java/src/org/chromium/ui/widget/PopupSpecCalculator.java
+--- a/ui/android/java/src/org/chromium/ui/widget/PopupSpecCalculator.java
++++ b/ui/android/java/src/org/chromium/ui/widget/PopupSpecCalculator.java
+@@ -233,8 +233,13 @@ public class PopupSpecCalculator implements SpecCalculator {
+                         - marginPx;
+ 
+         // Bias based on the center of the popup and where it is on the screen.
+-        final boolean idealFitsBelow = idealContentSize.getHeight() <= spaceBelowAnchor;
+-        final boolean idealFitsAbove = idealContentSize.getHeight() <= spaceAboveAnchor;
++        boolean idealFitsBelow = idealContentSize.getHeight() <= spaceBelowAnchor;
++        boolean idealFitsAbove = idealContentSize.getHeight() <= spaceAboveAnchor;
++
++        if (!idealFitsBelow && !idealFitsAbove) {
++            idealFitsAbove = (spaceBelowAnchor < spaceAboveAnchor);
++            idealFitsBelow = !idealFitsAbove;
++        }
+ 
+         // Determine whether or not the popup should be above or below the anchor.
+         // Aggressively try to put it below the anchor. Put it above only if it would fit
+diff --git a/ui/android/javatests/src/org/chromium/ui/test/util/UiDisableIfSkipCheck.java b/ui/android/javatests/src/org/chromium/ui/test/util/UiDisableIfSkipCheck.java
+--- a/ui/android/javatests/src/org/chromium/ui/test/util/UiDisableIfSkipCheck.java
++++ b/ui/android/javatests/src/org/chromium/ui/test/util/UiDisableIfSkipCheck.java
+@@ -28,17 +28,17 @@ public class UiDisableIfSkipCheck extends DisableIfSkipCheck {
+                 () -> {
+                     switch (type) {
+                         case DeviceFormFactor.PHONE:
+-                            return !DeviceInfo.isDesktop() && !isTablet();
++                            return !DeviceInfo.isDesktopFalse() && !isTablet();
+                         case DeviceFormFactor.ONLY_TABLET:
+-                            return !DeviceInfo.isDesktop() && isTablet();
++                            return !DeviceInfo.isDesktopFalse() && isTablet();
+                         case DeviceFormFactor.DESKTOP:
+-                            return DeviceInfo.isDesktop();
++                            return DeviceInfo.isDesktopFalse();
+                         case DeviceFormFactor.DESKTOP_FREEFORM:
+                             return UiRestriction.isDesktopFreeform();
+                         case DeviceFormFactor.TABLET_OR_DESKTOP:
+                             return isTablet();
+                         case DeviceFormFactor.PHONE_OR_TABLET:
+-                            return !DeviceInfo.isDesktop();
++                            return !DeviceInfo.isDesktopFalse();
+                         default:
+                             return false;
+                     }
+diff --git a/ui/android/javatests/src/org/chromium/ui/test/util/UiRestriction.java b/ui/android/javatests/src/org/chromium/ui/test/util/UiRestriction.java
+--- a/ui/android/javatests/src/org/chromium/ui/test/util/UiRestriction.java
++++ b/ui/android/javatests/src/org/chromium/ui/test/util/UiRestriction.java
+@@ -31,7 +31,7 @@ public final class UiRestriction {
+         if (sIsDesktop == null) {
+             // See the following link for implementation details:
+             // https://source.chromium.org/chromium/chromium/src/+/main:base/android/java/src/org/chromium/base/DeviceInfo.java;l=285-287;drc=61d3d9feb38d8045309dd9e237f5305de987523d
+-            sIsDesktop = DeviceInfo.isDesktop();
++            sIsDesktop = DeviceInfo.isDesktopFalse();
+         }
+         return sIsDesktop;
+     }
+@@ -50,7 +50,7 @@ public final class UiRestriction {
+         if (sIsDesktopFreeform == null) {
+             var packageManager = ContextUtils.getApplicationContext().getPackageManager();
+             sIsDesktopFreeform =
+-                    BuildConfig.IS_DESKTOP_ANDROID
++                    BuildConfig.IS_DESKTOP_ANDROID_FALSE
+                             && packageManager.hasSystemFeature(PackageManager.FEATURE_PC);
+         }
+ 
+diff --git a/ui/base/accelerators/command.cc b/ui/base/accelerators/command.cc
+--- a/ui/base/accelerators/command.cc
++++ b/ui/base/accelerators/command.cc
+@@ -86,7 +86,7 @@ std::string Command::CommandPlatform() {
+   // TODO(crbug.com/40220501): Change this once we decide what string should be
+   // used for Fuchsia.
+   return ui::kKeybindingPlatformLinux;
+-#elif BUILDFLAG(IS_DESKTOP_ANDROID)
++#elif BUILDFLAG(IS_DESKTOP_ANDROID_THORIUM)
+   // For now, we use linux keybindings on desktop android.
+   // TODO(https://crbug.com/356905053): Should this be ChromeOS keybindings?
+   return ui::kKeybindingPlatformLinux;
+diff --git a/ui/base/device_form_factor_android.cc b/ui/base/device_form_factor_android.cc
+--- a/ui/base/device_form_factor_android.cc
++++ b/ui/base/device_form_factor_android.cc
+@@ -26,7 +26,7 @@ DeviceFormFactor GetDeviceFormFactor() {
+     return DEVICE_FORM_FACTOR_AUTOMOTIVE;
+   }
+ 
+-  if (base::android::device_info::is_desktop()) {
++  if (base::android::device_info::is_desktop_false()) {
+     return DEVICE_FORM_FACTOR_DESKTOP;
+   }
+ 
+diff --git a/ui/gl/features.gni b/ui/gl/features.gni
+--- a/ui/gl/features.gni
++++ b/ui/gl/features.gni
+@@ -14,7 +14,7 @@ declare_args() {
+   # Vulkan Validation Layers.
+   use_dawn = is_apple || is_win || is_chromeos || (is_linux && !is_castos) ||
+              (is_android && target_cpu != "x86" && target_cpu != "x64") ||
+-             is_desktop_android
++             is_desktop_android_false_thorium
+ 
+   # Should Dawn test binaries (unittests, end2end_tests, perf_tests) be built?
+   # Independent of use_dawn, which controls whether Dawn is used in Chromium.
+diff --git a/ui/resources/ui_resources.grd b/ui/resources/ui_resources.grd
+--- a/ui/resources/ui_resources.grd
++++ b/ui/resources/ui_resources.grd
+@@ -28,7 +28,7 @@
+       </if>
+       <structure type="chrome_scaled_image" name="IDR_DEFAULT_FAVICON" file="common/default_favicon.png" />
+       <structure type="chrome_scaled_image" name="IDR_DEFAULT_FAVICON_DARK" file="common/default_favicon_dark.png" />
+-      <if expr="not is_android or is_desktop_android">
++      <if expr="not is_android or is_desktop_android_thorium">
+         <structure type="chrome_scaled_image" name="IDR_DEFAULT_FAVICON_32" file="common/default_favicon_32.png" />
+         <structure type="chrome_scaled_image" name="IDR_DEFAULT_FAVICON_DARK_32" file="common/default_favicon_dark_32.png" />
+         <structure type="chrome_scaled_image" name="IDR_DEFAULT_FAVICON_64" file="common/default_favicon_64.png" />
+diff --git a/ui/webui/resources/BUILD.gn b/ui/webui/resources/BUILD.gn
+--- a/ui/webui/resources/BUILD.gn
++++ b/ui/webui/resources/BUILD.gn
+@@ -67,7 +67,7 @@ generate_grd("build_grd") {
+       "$target_gen_dir/cr_components/theme_color_picker/resources.grdp",
+       "$root_gen_dir/third_party/polymer/v3_0/polymer_3_0_resources.grdp",
+     ]
+-    if (!is_desktop_android) {
++    if (!is_desktop_android_thorium) {
+       public_deps += [
+         "cr_components/cr_shortcut_input:build_grdp",
+         "cr_components/managed_footnote:build_grdp",
+@@ -78,7 +78,7 @@ generate_grd("build_grd") {
+       ]
+     }
+   }
+-  if ((!is_android && !is_ios) || is_desktop_android) {
++  if ((!is_android && !is_ios) || is_desktop_android_thorium) {
+     public_deps += [
+       "cr_components/cr_shortcut_input:build_grdp",
+       "cr_components/managed_footnote:build_grdp",
+diff --git a/ui/webui/resources/cr_elements/BUILD.gn b/ui/webui/resources/cr_elements/BUILD.gn
+--- a/ui/webui/resources/cr_elements/BUILD.gn
++++ b/ui/webui/resources/cr_elements/BUILD.gn
+@@ -49,7 +49,7 @@ build_webui("build") {
+     "cr_tabs/cr_tabs.css",
+   ]
+ 
+-  if ((!is_ios) || is_desktop_android) {
++  if ((!is_ios) || is_desktop_android_thorium) {
+     web_component_files += [ "cr_a11y_announcer/cr_a11y_announcer.ts" ]
+ 
+     ts_files += [
+diff --git a/ui/webui/resources/cr_elements/cr_toolbar/cr_toolbar.css b/ui/webui/resources/cr_elements/cr_toolbar/cr_toolbar.css
+--- a/ui/webui/resources/cr_elements/cr_toolbar/cr_toolbar.css
++++ b/ui/webui/resources/cr_elements/cr_toolbar/cr_toolbar.css
+@@ -123,6 +123,9 @@ picture {
+ }
+ 
+ #menuButton ~ h1 {
++<if expr="is_android">
++  font-size: 15px !important;
++</if>
+   margin-inline-start: 0;
+ }
+ 
+diff --git a/ui/webui/resources/css/BUILD.gn b/ui/webui/resources/css/BUILD.gn
+--- a/ui/webui/resources/css/BUILD.gn
++++ b/ui/webui/resources/css/BUILD.gn
+@@ -35,7 +35,7 @@ preprocess_if_expr("preprocess") {
+     in_files += [ "roboto.css" ]
+   }
+ 
+-  if (include_polymer || is_desktop_android) {
++  if (include_polymer || is_desktop_android_thorium) {
+     in_files += [ "md_colors.css" ]
+   }
+ }
+--

--- a/other/enable-extensions-android-thorium.patch
+++ b/other/enable-extensions-android-thorium.patch
@@ -247,7 +247,7 @@ diff --git a/base/android/device_info.cc b/base/android/device_info.cc
  }
  
 -bool is_desktop() {
-+bool is_desktop_cromite() {
++bool is_desktop_thorium() {
    return get_device_info().isDesktop;
  }
  
@@ -275,7 +275,7 @@ diff --git a/base/android/device_info.h b/base/android/device_info.h
  BASE_EXPORT bool is_automotive();
  BASE_EXPORT bool is_foldable();
 -BASE_EXPORT bool is_desktop();
-+BASE_EXPORT bool is_desktop_cromite();
++BASE_EXPORT bool is_desktop_thorium();
 +BASE_EXPORT bool is_desktop_false();
  // Available only on Android T+.
  BASE_EXPORT int32_t vulkan_deqp_level();
@@ -288,7 +288,7 @@ diff --git a/base/android/java/src/org/chromium/base/DeviceInfo.java b/base/andr
      }
  
 -    public static boolean isDesktop() {
-+    public static boolean isDesktopCromite() {
++    public static boolean isDesktopThorium() {
          return getInstance().mIDeviceInfo.isDesktop;
      }
  
@@ -708,7 +708,7 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tabbed_mode/Tab
              // isActivityStateBookmarkBarCompatible already checks the flag sAndroidBookmarkBar.
              if (BookmarkBarUtils.isActivityStateBookmarkBarCompatible(mActivity)) {
 -                if (DeviceInfo.isDesktop()) {
-+                if (DeviceInfo.isDesktopCromite()) {
++                if (DeviceInfo.isDesktopThorium()) {
                      // Desktop uses the synced UserPref.
                      BookmarkBarUtils.toggleUserPrefsShowBookmarksBar(
                              mProfileSupplier.get(), /* fromKeyboardShortcut= */ true);
@@ -3387,11 +3387,11 @@ diff --git a/extensions/browser/extension_host.cc b/extensions/browser/extension
 +
 +#if BUILDFLAG(IS_ANDROID)
 +  if (extension_host_type() == mojom::ViewType::kExtensionPopup) {
-+    constexpr char kOsOverrideForCromite[] = "Linux; Android 10; Cromite";
++    constexpr char kOsOverrideForThorium[] = "Linux; Android 10; Thorium";
 +    const std::string product = embedder_support::GetProductAndVersion();
 +    blink::UserAgentOverride ua_override;
 +    ua_override.ua_string_override =
-+        embedder_support::BuildUserAgentFromOSAndProduct(kOsOverrideForCromite,
++        embedder_support::BuildUserAgentFromOSAndProduct(kOsOverrideForThorium,
 +                                                        product);
 +    host_contents_->SetUserAgentOverride(ua_override,
 +                                         false /*override_in_new_tabs=*/);

--- a/setup.sh
+++ b/setup.sh
@@ -104,6 +104,8 @@ patchThor () {
 	cp -v other/win_updater.patch ${CR_SRC_DIR}/ &&
 	cp -v other/keyboard_shortcuts.patch ${CR_SRC_DIR}/ &&
 	cp -v other/multi-language-translate.patch ${CR_SRC_DIR}/ &&
+	cp -v other/enable-extensions-android-thorium.patch ${CR_SRC_DIR}/ &&
+	cp -v other/enable-extension-incognito-thorium.patch ${CR_SRC_DIR}/ &&
 	# Starting with M144, the following patches can be removed
 	cp -v other/partalloc.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_profile_selector_crash.patch ${CR_SRC_DIR}/ &&
@@ -141,6 +143,13 @@ patchThor () {
 	printf "${YEL}Patching in GPC support...${c0}\n" &&
 	cd ${CR_SRC_DIR} &&
 	git apply --reject ./GPC.patch &&
+
+	printf "\n" &&
+	printf "${YEL}Patching in Android extensions support...${c0}\n" &&
+	cd ${CR_SRC_DIR} &&
+	git apply --reject ./enable-extensions-android-thorium.patch &&
+	printf "${YEL}Patching in extension incognito support...${c0}\n" &&
+	git apply --reject ./enable-extension-incognito-thorium.patch &&
 
 	printf "\n" &&
 	printf "${YEL}Patching for Thorium 2024 UI...${c0}\n" &&

--- a/setup.sh
+++ b/setup.sh
@@ -104,8 +104,6 @@ patchThor () {
 	cp -v other/win_updater.patch ${CR_SRC_DIR}/ &&
 	cp -v other/keyboard_shortcuts.patch ${CR_SRC_DIR}/ &&
 	cp -v other/multi-language-translate.patch ${CR_SRC_DIR}/ &&
-	cp -v other/enable-extensions-android-thorium.patch ${CR_SRC_DIR}/ &&
-	cp -v other/enable-extension-incognito-thorium.patch ${CR_SRC_DIR}/ &&
 	# Starting with M144, the following patches can be removed
 	cp -v other/partalloc.patch ${CR_SRC_DIR}/ &&
 	cp -v other/fix_profile_selector_crash.patch ${CR_SRC_DIR}/ &&
@@ -143,13 +141,6 @@ patchThor () {
 	printf "${YEL}Patching in GPC support...${c0}\n" &&
 	cd ${CR_SRC_DIR} &&
 	git apply --reject ./GPC.patch &&
-
-	printf "\n" &&
-	printf "${YEL}Patching in Android extensions support...${c0}\n" &&
-	cd ${CR_SRC_DIR} &&
-	git apply --reject ./enable-extensions-android-thorium.patch &&
-	printf "${YEL}Patching in extension incognito support...${c0}\n" &&
-	git apply --reject ./enable-extension-incognito-thorium.patch &&
 
 	printf "\n" &&
 	printf "${YEL}Patching for Thorium 2024 UI...${c0}\n" &&
@@ -396,6 +387,14 @@ copyAndroid () {
 	#rm -v -f ${CR_SRC_DIR}/chrome/android/java/res_chromium_base/mipmap-hdpi/layered_app_icon.png &&
 	rm -v -f ${CR_SRC_DIR}/chrome/android/java/res_chromium_base/mipmap-xxhdpi/layered_app_icon_background.png &&
 	#rm -v -f ${CR_SRC_DIR}/chrome/android/java/res_chromium_base/mipmap-xxhdpi/layered_app_icon.png &&
+	[ -f ${CR_SRC_DIR}/enable-extensions-android-thorium.patch ] || cp -v other/enable-extensions-android-thorium.patch ${CR_SRC_DIR}/ &&
+	[ -f ${CR_SRC_DIR}/enable-extension-incognito-thorium.patch ] || cp -v other/enable-extension-incognito-thorium.patch ${CR_SRC_DIR}/ &&
+	printf "\n" &&
+	printf "${YEL}Patching in Android extensions support...${c0}\n" &&
+	cd ${CR_SRC_DIR} &&
+	git apply --reject ./enable-extensions-android-thorium.patch &&
+	printf "${YEL}Patching in extension incognito support...${c0}\n" &&
+	git apply --reject ./enable-extension-incognito-thorium.patch &&
 	#./infra/fix_libaom.sh &&
 	printf "\n" &&
 	printf "${YEL}Downloading PGO profiles...${c0}\n" &&

--- a/setup.sh
+++ b/setup.sh
@@ -387,8 +387,8 @@ copyAndroid () {
 	#rm -v -f ${CR_SRC_DIR}/chrome/android/java/res_chromium_base/mipmap-hdpi/layered_app_icon.png &&
 	rm -v -f ${CR_SRC_DIR}/chrome/android/java/res_chromium_base/mipmap-xxhdpi/layered_app_icon_background.png &&
 	#rm -v -f ${CR_SRC_DIR}/chrome/android/java/res_chromium_base/mipmap-xxhdpi/layered_app_icon.png &&
-	[ -f ${CR_SRC_DIR}/enable-extensions-android-thorium.patch ] || cp -v other/enable-extensions-android-thorium.patch ${CR_SRC_DIR}/ &&
-	[ -f ${CR_SRC_DIR}/enable-extension-incognito-thorium.patch ] || cp -v other/enable-extension-incognito-thorium.patch ${CR_SRC_DIR}/ &&
+	cp -v other/enable-extensions-android-thorium.patch ${CR_SRC_DIR}/ &&
+	cp -v other/enable-extension-incognito-thorium.patch ${CR_SRC_DIR}/ &&
 	printf "\n" &&
 	printf "${YEL}Patching in Android extensions support...${c0}\n" &&
 	cd ${CR_SRC_DIR} &&


### PR DESCRIPTION
## Summary
Integrate Cromite's Android extension support into Thorium's patch workflow and documentation.

## Changes
- Added `other/enable-extensions-android-thorium.patch` adapted from Cromite's experimental Android extension support patch.
- Added `other/enable-extension-incognito-thorium.patch` adapted from Cromite's Android incognito extension support patch.
- Updated `setup.sh` to copy and apply both new patches during `patchThor()`.
- Updated `docs/PATCHES.md` with entries for both newly integrated patches.

## Notes
- The imported patches remain GPL-2.0-or-later as in the original Cromite sources.
- This integrates the feature as Thorium-applied patches; runtime behavior is controlled by the patch content and Chromium/Thorium build/runtime flags.

## Validation
- `bash -n setup.sh`
- `bash -n build_android.sh`